### PR TITLE
App launcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,12 +8,10 @@ target/
 # Distribution
 distribution/jpackage-out
 distribution/DisplayHotKeys.exe
+distribution/DisplayHotKeysLauncher.exe
 distribution/DisplayHotKeysInstaller.exe
 
 # JNI DLLs
 GetDisplay.dll
 SetDisplay.dll
 DisplayEventNotifier.dll
-GetDisplay.res.o
-SetDisplay.res.o
-DisplayEventNotifier.res.o

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This project was created to circumvent the tedious navigation of the Windows set
 
 * Enlarge or shrink the elements on screen by instantly changing the DPI scale percentage.
 
-* Instantly set a display mode while in a video game if it does not support changing the resolution or refresh rate while in-game.
+* Instantly set resolution and refresh rate while in a video game if it does not support changing these settings while in-game.
 
 * Retain your intended display arrangement while changing display resolutions.
 
@@ -56,7 +56,11 @@ This project was created to circumvent the tedious navigation of the Windows set
 
 ## Getting Started
 
-This application was made only for the Windows platform. Display Hot Keys also uses elevated privileges to set display modes while in video games. Therefore, if you have UAC enabled, you will get a UAC prompt upon launching the application. If you no longer wish to see this prompt, you can [disable UAC]. The sections that follow will help you get the application up and running on your PC!
+This application was made only for the Windows platform. Display Hot Keys also uses elevated privileges to set display settings while in video games and when an app with elevated privileges has focus. Therefore, if you have UAC enabled, you will get a UAC prompt the first time you launch the application. That first launch registers a Windows task that starts Display Hot Keys with the privileges it needs, so every launch after that starts the application without a UAC prompt. The sections that follow will help you get the application up and running on your PC!
+
+**Note:** Always start Display Hot Keys from the shortcut created by the installer, or from DisplayHotKeysLauncher.exe in the install directory. Only the launcher can start the application through the Windows task, which is what avoids the prompt. Starting DisplayHotKeys.exe yourself asks Windows for elevated privileges directly, so it prompts every time no matter how often you run it.
+
+**Note:** Registering the Windows task requires administrator rights. If you are signed in with a standard user account, the task cannot be registered and you will get a UAC prompt on every launch. If you no longer wish to see this prompt, you can [disable UAC].
 
 ### Prerequisites
 
@@ -72,7 +76,7 @@ This application will be distributed as a portable package and as an installer. 
 
 2. Unzip the archive.
 
-3. Double-click the DisplayHotKeys executable file or create a shortcut to run the application.
+3. Double-click the DisplayHotKeysLauncher executable file or create a shortcut to the launcher to run the application.
 
 #### Installer
 
@@ -82,7 +86,7 @@ This application will be distributed as a portable package and as an installer. 
 
 3. Follow the installer prompts.
 
-4. Double-click the created shortcut or the DisplayHotKeys executable file in the install directory to run the application.
+4. Double-click the created shortcut or the DisplayHotKeysLauncher executable file in the install directory to run the application.
 
 <p align="right"><a href="#readme-top">Back to Top</a>&thinsp; &#x25B2;</p>
 
@@ -196,7 +200,7 @@ Opens a web page in the default browser to display the releases for Display Hot 
 - [x] &thinsp; Add scaling mode selection.
 - [x] &thinsp; Add multi-display support.
 - [x] &thinsp; Add display orientation selection.
-- [x] &thinsp; Add button to immediately apply display modes.
+- [x] &thinsp; Add button to immediately apply display settings.
 - [x] &thinsp; Add a minimize to tray toggle.
 - [x] &thinsp; Add ability to change display orientation with hot keys.
 - [x] &thinsp; Add an "About" view to display current app information.

--- a/distribution/DisplayHotKeysInstaller.iss
+++ b/distribution/DisplayHotKeysInstaller.iss
@@ -2,6 +2,7 @@
 #define MySettingsDirName "DisplayHotKeys"
 #define MySettingsFileName "settings.ini"
 #define MyLockFileName "DisplayHotKeys.lock"
+#define MyStartupFilePath "AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\StartDisplayHotKeys.bat"
 #define ProfileListKey "SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList"
 #define MyAppVersion "4.0.5"
 #define MyAppCopyright "Copyright (C) 2026 Jonathan R. Miller"
@@ -88,7 +89,7 @@ begin
     SW_HIDE, ewWaitUntilTerminated, TaskKillResultCode);
 
   // Give Windows a moment to release the file handles the terminated processes held
-  Sleep(1500);
+  Sleep(1000);
 end;
 
 procedure RemoveTask;
@@ -103,11 +104,10 @@ begin
   DeleteFile(ExpandConstant('{sys}\Tasks\{#MyAppName}'));
 end;
 
-function GetProfileSettingsDirs: TStringList;
+function GetUserProfileRoots: TStringList;
 var
   ProfileSids: TArrayOfString;
   ProfilePath: String;
-  SettingsDir: String;
   SidIndex: Integer;
 begin
   Result := TStringList.Create;
@@ -117,19 +117,52 @@ begin
 
   for SidIndex := 0 to GetArrayLength(ProfileSids) - 1 do
   begin
-    // Only user accounts hold settings, so this prefix skips the built-in system and service profiles
+    // Only user accounts hold app state, so this prefix skips the built-in system and service profiles
     if Pos('S-1-5-21-', ProfileSids[SidIndex]) <> 1 then
       Continue;
 
-    if not RegQueryStringValue(HKEY_LOCAL_MACHINE, '{#ProfileListKey}\' + ProfileSids[SidIndex], 'ProfileImagePath',
+    if RegQueryStringValue(HKEY_LOCAL_MACHINE, '{#ProfileListKey}\' + ProfileSids[SidIndex], 'ProfileImagePath',
       ProfilePath) then
-      Continue;
+      Result.Add(ProfilePath);
+  end;
+end;
 
-    // The app builds this path from the profile root itself, so resolve it the same way rather than via a shell folder
-    SettingsDir := ProfilePath + '\Documents\{#MySettingsDirName}';
+function GetProfileSettingsDirs: TStringList;
+var
+  ProfileRoots: TStringList;
+  SettingsDir: String;
+  RootIndex: Integer;
+begin
+  Result := TStringList.Create;
+  ProfileRoots := GetUserProfileRoots;
 
-    if DirExists(SettingsDir) then
-      Result.Add(SettingsDir);
+  try
+    for RootIndex := 0 to ProfileRoots.Count - 1 do
+    begin
+      // The app builds this path from the profile root itself
+      SettingsDir := ProfileRoots[RootIndex] + '\Documents\{#MySettingsDirName}';
+
+      if DirExists(SettingsDir) then
+        Result.Add(SettingsDir);
+    end;
+  finally
+    ProfileRoots.Free;
+  end;
+end;
+
+procedure RemoveStartupFiles;
+var
+  ProfileRoots: TStringList;
+  RootIndex: Integer;
+begin
+  ProfileRoots := GetUserProfileRoots;
+
+  try
+    // The app falls back to this file when it cannot register the task, so it would fail to start at every login
+    for RootIndex := 0 to ProfileRoots.Count - 1 do
+      DeleteFile(ProfileRoots[RootIndex] + '\{#MyStartupFilePath}');
+  finally
+    ProfileRoots.Free;
   end;
 end;
 
@@ -189,6 +222,7 @@ begin
   if CurUninstallStep = usUninstall then
   begin
     RemoveTask;
+    RemoveStartupFiles;
     RemoveSettings;
   end;
 end;

--- a/distribution/DisplayHotKeysInstaller.iss
+++ b/distribution/DisplayHotKeysInstaller.iss
@@ -23,6 +23,7 @@ AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
+UninstallDisplayIcon={app}\{#MyAppExeName}
 DefaultDirName={autopf}\{#MyAppName}
 DisableDirPage=yes
 DisableProgramGroupPage=yes
@@ -34,6 +35,7 @@ Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
 CloseApplications=force
+CloseApplicationsFilter=*.exe,*.dll
 RestartApplications=no
 
 [Languages]
@@ -43,11 +45,8 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "{#DistDir}\jpackage-out\DisplayHotKeys\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "{#DistDir}\AGPL_3.0_LICENSE_3RD_PARTY.txt"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#DistDir}\APACHE_2.0_LICENSE_3RD_PARTY.txt"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#ProjectDir}\LICENSE.txt"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#DistDir}\README.txt"; DestDir: "{app}"; Flags: ignoreversion
+// The portable cleanup script ships only in the portable package, so exclude it
+Source: "{#DistDir}\jpackage-out\DisplayHotKeys\*"; DestDir: "{app}"; Excludes: "uninstall.bat"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
 Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppLauncherExeName}"
@@ -80,12 +79,16 @@ procedure ForceCloseRunningApp;
 var
   TaskKillResultCode: Integer;
 begin
-  // Force close the running app (the launcher and its JVM child) before its files are removed
+  // Force close the running app (the launcher and its JVM child) before its files are replaced or removed
   Exec(ExpandConstant('{sys}\taskkill.exe'), '/f /t /im {#MyAppExeName}', '',
     SW_HIDE, ewWaitUntilTerminated, TaskKillResultCode);
 
+  // The launcher is a separate image, so it survives the kill above and can still hold a handle
+  Exec(ExpandConstant('{sys}\taskkill.exe'), '/f /t /im {#MyAppLauncherExeName}', '',
+    SW_HIDE, ewWaitUntilTerminated, TaskKillResultCode);
+
   // Give Windows a moment to release the file handles the terminated processes held
-  Sleep(1000);
+  Sleep(1500);
 end;
 
 procedure RemoveTask;
@@ -165,11 +168,26 @@ begin
   end;
 end;
 
+function PrepareToInstall(var NeedsRestart: Boolean): String;
+begin
+  // Close the app before the in-use scan runs, so an upgrade over a running copy never prompts
+  ForceCloseRunningApp;
+
+  // An empty result lets the installation proceed
+  Result := '';
+end;
+
+function InitializeUninstall: Boolean;
+begin
+  // Close the app before the in-use scan runs, so the uninstaller never prompts about the running processes
+  ForceCloseRunningApp;
+  Result := True;
+end;
+
 procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
 begin
   if CurUninstallStep = usUninstall then
   begin
-    ForceCloseRunningApp;
     RemoveTask;
     RemoveSettings;
   end;

--- a/distribution/DisplayHotKeysInstaller.iss
+++ b/distribution/DisplayHotKeysInstaller.iss
@@ -1,4 +1,8 @@
 #define MyAppName "Display Hot Keys"
+#define MySettingsDirName "DisplayHotKeys"
+#define MySettingsFileName "settings.ini"
+#define MyLockFileName "DisplayHotKeys.lock"
+#define ProfileListKey "SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList"
 #define MyAppVersion "4.0.5"
 #define MyAppCopyright "Copyright (C) 2026 Jonathan R. Miller"
 #define MyAppPublisher "Jonathan R. Miller"
@@ -68,6 +72,10 @@ Type: filesandordirs; Name: {app}\GetDisplay.dll;
 Type: filesandordirs; Name: {app}\DisplayEventNotifier.dll;
 
 [Code]
+const
+  // Blank line between message box paragraphs, since Pascal strings carry no escape sequence for a line break
+  NewParagraph = #13#10#13#10;
+
 procedure ForceCloseRunningApp;
 var
   TaskKillResultCode: Integer;
@@ -87,6 +95,74 @@ begin
   // Delete the task that would otherwise outlive the uninstall and fail to start every login
   Exec(ExpandConstant('{sys}\schtasks.exe'), '/Delete /TN "{#MyAppName}" /F', '',
     SW_HIDE, ewWaitUntilTerminated, TaskDeleteResultCode);
+
+  // The command above only reaches the uninstalling user, so drop the stored definition to clear all tasks
+  DeleteFile(ExpandConstant('{sys}\Tasks\{#MyAppName}'));
+end;
+
+function GetProfileSettingsDirs: TStringList;
+var
+  ProfileSids: TArrayOfString;
+  ProfilePath: String;
+  SettingsDir: String;
+  SidIndex: Integer;
+begin
+  Result := TStringList.Create;
+
+  if not RegGetSubkeyNames(HKEY_LOCAL_MACHINE, '{#ProfileListKey}', ProfileSids) then
+    Exit;
+
+  for SidIndex := 0 to GetArrayLength(ProfileSids) - 1 do
+  begin
+    // Only user accounts hold settings, so this prefix skips the built-in system and service profiles
+    if Pos('S-1-5-21-', ProfileSids[SidIndex]) <> 1 then
+      Continue;
+
+    if not RegQueryStringValue(HKEY_LOCAL_MACHINE, '{#ProfileListKey}\' + ProfileSids[SidIndex], 'ProfileImagePath',
+      ProfilePath) then
+      Continue;
+
+    // The app builds this path from the profile root itself, so resolve it the same way rather than via a shell folder
+    SettingsDir := ProfilePath + '\Documents\{#MySettingsDirName}';
+
+    if DirExists(SettingsDir) then
+      Result.Add(SettingsDir);
+  end;
+end;
+
+procedure RemoveSettings;
+var
+  SettingsDirs: TStringList;
+  SettingsPrompt: String;
+  DirIndex: Integer;
+begin
+  SettingsDirs := GetProfileSettingsDirs;
+
+  try
+    // Only offer to delete settings that actually exist, so a clean uninstall is not interrupted
+    if SettingsDirs.Count = 0 then
+      Exit;
+
+    SettingsPrompt := 'Do you also want to delete the saved {#MyAppName} settings for all users?';
+    SettingsPrompt := SettingsPrompt + NewParagraph;
+    SettingsPrompt := SettingsPrompt + 'Keeping them preserves saved slots if you reinstall.';
+
+    if SuppressibleMsgBox(SettingsPrompt, mbConfirmation, MB_YESNO or MB_DEFBUTTON2, IDNO) <> IDYES then
+      Exit;
+
+    for DirIndex := 0 to SettingsDirs.Count - 1 do
+    begin
+      DeleteFile(SettingsDirs[DirIndex] + '\{#MySettingsFileName}');
+
+      // The app leaves its single-instance lock file behind on exit, which would otherwise keep the folder populated
+      DeleteFile(SettingsDirs[DirIndex] + '\{#MyLockFileName}');
+
+      // Leave the folder alone unless the removed files were the only things in it
+      RemoveDir(SettingsDirs[DirIndex]);
+    end;
+  finally
+    SettingsDirs.Free;
+  end;
 end;
 
 procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
@@ -95,5 +171,6 @@ begin
   begin
     ForceCloseRunningApp;
     RemoveTask;
+    RemoveSettings;
   end;
 end;

--- a/distribution/DisplayHotKeysInstaller.iss
+++ b/distribution/DisplayHotKeysInstaller.iss
@@ -1,9 +1,10 @@
 #define MyAppName "Display Hot Keys"
-#define MyAppVersion "4.0.4"
+#define MyAppVersion "4.0.5"
 #define MyAppCopyright "Copyright (C) 2026 Jonathan R. Miller"
 #define MyAppPublisher "Jonathan R. Miller"
 #define MyAppURL "https://github.com/jon-mil-92/DisplayHotKeys"
 #define MyAppExeName "DisplayHotKeys.exe"
+#define MyAppLauncherExeName "DisplayHotKeysLauncher.exe"
 #define DistDir SourcePath
 #define ProjectDir SourcePath + "\.."
 
@@ -45,11 +46,12 @@ Source: "{#ProjectDir}\LICENSE.txt"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#DistDir}\README.txt"; DestDir: "{app}"; Flags: ignoreversion
 
 [Icons]
-Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
-Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppLauncherExeName}"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppLauncherExeName}"; Tasks: desktopicon
 
 [InstallDelete]
 Type: filesandordirs; Name: {app}\DisplayHotKeys.exe;
+Type: filesandordirs; Name: {app}\DisplayHotKeysLauncher.exe;
 Type: filesandordirs; Name: {app}\SetDisplay.exe;
 Type: filesandordirs; Name: {app}\APACHE_LICENSE_3RD_PARTY.txt;
 Type: filesandordirs; Name: {app}\LICENSE.txt;
@@ -78,8 +80,20 @@ begin
   Sleep(1000);
 end;
 
+procedure RemoveTask;
+var
+  TaskDeleteResultCode: Integer;
+begin
+  // Delete the task that would otherwise outlive the uninstall and fail to start every login
+  Exec(ExpandConstant('{sys}\schtasks.exe'), '/Delete /TN "{#MyAppName}" /F', '',
+    SW_HIDE, ewWaitUntilTerminated, TaskDeleteResultCode);
+end;
+
 procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
 begin
   if CurUninstallStep = usUninstall then
+  begin
     ForceCloseRunningApp;
+    RemoveTask;
+  end;
 end;

--- a/distribution/README.txt
+++ b/distribution/README.txt
@@ -14,7 +14,7 @@ This project was created to circumvent the tedious navigation of the Windows set
 
 * Enlarge or shrink the elements on screen by instantly changing the DPI scale percentage.
 
-* Instantly set a display mode while in a video game if it does not support changing the resolution or refresh rate while in-game.
+* Instantly set resolution and refresh rate while in a video game if it does not support changing these settings while in-game.
 
 * Retain your intended display arrangement while changing display resolutions.
 
@@ -22,7 +22,11 @@ This project was created to circumvent the tedious navigation of the Windows set
 
 ## Getting Started
 
-This application was made only for the Windows platform. Display Hot Keys also uses elevated privileges to set display modes while in video games. Therefore, if you have UAC enabled, you will get a UAC prompt upon launching the application. If you no longer wish to see this prompt, you can [disable UAC]. The sections that follow will help you get the application up and running on your PC!
+This application was made only for the Windows platform. Display Hot Keys also uses elevated privileges to set display settings while in video games and when an app with elevated privileges has focus. Therefore, if you have UAC enabled, you will get a UAC prompt the first time you launch the application. That first launch registers a Windows task that starts Display Hot Keys with the privileges it needs, so every launch after that starts the application without a UAC prompt. The sections that follow will help you get the application up and running on your PC!
+
+**Note:** Always start Display Hot Keys from the shortcut created by the installer, or from DisplayHotKeysLauncher.exe in the install directory. Only the launcher can start the application through the Windows task, which is what avoids the prompt. Starting DisplayHotKeys.exe yourself asks Windows for elevated privileges directly, so it prompts every time no matter how often you run it.
+
+**Note:** Registering the Windows task requires administrator rights. If you are signed in with a standard user account, the task cannot be registered and you will get a UAC prompt on every launch. If you no longer wish to see this prompt, you can [disable UAC].
 
 ### Prerequisites
 
@@ -38,7 +42,7 @@ This application will be distributed as a portable package and as an installer. 
 
 2. Unzip the archive.
 
-3. Double-click the DisplayHotKeys executable file or create a shortcut to run the application.
+3. Double-click the DisplayHotKeysLauncher executable file or create a shortcut to the launcher to run the application.
 
 #### Installer
 
@@ -48,7 +52,7 @@ This application will be distributed as a portable package and as an installer. 
 
 3. Follow the installer prompts.
 
-4. Double-click the created shortcut or the DisplayHotKeys executable file in the install directory to run the application.
+4. Double-click the created shortcut or the DisplayHotKeysLauncher executable file in the install directory to run the application.
 
 ## Usage
 

--- a/distribution/build-app-image.ps1
+++ b/distribution/build-app-image.ps1
@@ -17,6 +17,15 @@ $launcherProperties = Join-Path $resourceDir 'DisplayHotKeys.properties'
 $dllNames = @('SetDisplay.dll', 'GetDisplay.dll', 'DisplayEventNotifier.dll')
 $startLauncherName = 'DisplayHotKeysLauncher.exe'
 $startLauncher = Join-Path $distDir $startLauncherName
+$uninstallScript = Join-Path $distDir 'uninstall.bat'
+
+# The license lives at the project root while the readme and third-party licenses ship from the distribution folder
+$docFiles = @(
+    (Join-Path $projectDir 'LICENSE.txt'),
+    (Join-Path $distDir 'README.txt'),
+    (Join-Path $distDir 'AGPL_3.0_LICENSE_3RD_PARTY.txt'),
+    (Join-Path $distDir 'APACHE_2.0_LICENSE_3RD_PARTY.txt')
+)
 
 try {
     # Resolve required tools without assuming a fixed drive or PATH layout
@@ -98,7 +107,7 @@ try {
     }
 
     # Verify the remaining packaging inputs exist before building
-    foreach ($required in @($icon, $manifest, $launcherProperties, $startLauncher) + ($dllNames | ForEach-Object { Join-Path $distDir $_ })) {
+    foreach ($required in @($icon, $manifest, $launcherProperties, $startLauncher, $uninstallScript) + $docFiles + ($dllNames | ForEach-Object { Join-Path $distDir $_ })) {
         if (-not (Test-Path $required)) {
             throw "Required build input not found: $required"
         }
@@ -183,9 +192,21 @@ try {
     }
 
     # Place the unelevated launcher beside the app executable so shortcuts start the app without a consent prompt
-    Write-Host 'Copying the start launcher into the app image...'
+    Write-Host 'Copying the launcher into the app image...'
 
     Copy-Item $startLauncher $appImage
+
+    # A portable copy has no uninstaller, so ship the cleanup script that removes the task it leaves behind
+    Write-Host 'Copying the portable uninstall script into the app image...'
+
+    Copy-Item $uninstallScript $appImage
+
+    # Ship the readme and licenses beside the app so the image is the complete portable package
+    Write-Host 'Copying the readme and license files into the app image...'
+
+    foreach ($docFile in $docFiles) {
+        Copy-Item $docFile $appImage
+    }
 
     # The input folder is only staging for jpackage, so clean it up
     Remove-Item $inputDir -Recurse -Force

--- a/distribution/build-app-image.ps1
+++ b/distribution/build-app-image.ps1
@@ -2,7 +2,7 @@
 
 $distDir = $PSScriptRoot
 $projectDir = Split-Path $distDir -Parent
-$version = '4.0.4'
+$version = '4.0.5'
 $jarName = "DisplayHotKeys-$version.jar"
 $copyright = "Copyright $([char]0x00A9) 2026 Jonathan R. Miller"
 $ErrorActionPreference = 'Stop'
@@ -15,6 +15,8 @@ $icon = Join-Path $distDir 'dhk.ico'
 $resourceDir = Join-Path $distDir 'jpackage-resources'
 $launcherProperties = Join-Path $resourceDir 'DisplayHotKeys.properties'
 $dllNames = @('SetDisplay.dll', 'GetDisplay.dll', 'DisplayEventNotifier.dll')
+$startLauncherName = 'DisplayHotKeysLauncher.exe'
+$startLauncher = Join-Path $distDir $startLauncherName
 
 try {
     # Resolve required tools without assuming a fixed drive or PATH layout
@@ -96,7 +98,7 @@ try {
     }
 
     # Verify the remaining packaging inputs exist before building
-    foreach ($required in @($icon, $manifest, $launcherProperties) + ($dllNames | ForEach-Object { Join-Path $distDir $_ })) {
+    foreach ($required in @($icon, $manifest, $launcherProperties, $startLauncher) + ($dllNames | ForEach-Object { Join-Path $distDir $_ })) {
         if (-not (Test-Path $required)) {
             throw "Required build input not found: $required"
         }
@@ -179,6 +181,11 @@ try {
     if ($LASTEXITCODE -ne 0) {
         throw 'mt.exe manifest injection failed'
     }
+
+    # Place the unelevated launcher beside the app executable so shortcuts start the app without a consent prompt
+    Write-Host 'Copying the start launcher into the app image...'
+
+    Copy-Item $startLauncher $appImage
 
     # The input folder is only staging for jpackage, so clean it up
     Remove-Item $inputDir -Recurse -Force

--- a/distribution/uninstall.bat
+++ b/distribution/uninstall.bat
@@ -1,0 +1,132 @@
+@echo off
+setlocal EnableExtensions
+
+rem Cleans up what a portable copy of Display Hot Keys leaves outside its own folder: the scheduled task, the
+rem startup folder fallback, and optionally the saved settings. Deleting the folder alone leaves the task
+rem registered, where it fails to start at every login.
+
+set "APP_NAME=Display Hot Keys"
+set "APP_EXE=DisplayHotKeys.exe"
+set "SETTINGS_DIR=%USERPROFILE%\Documents\DisplayHotKeys"
+set "SETTINGS_FILE=%SETTINGS_DIR%\settings.ini"
+set "LOCK_FILE=%SETTINGS_DIR%\DisplayHotKeys.lock"
+set "STARTUP_FILE=%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup\StartDisplayHotKeys.bat"
+set "ELEVATION_SCRIPT=%TEMP%\DisplayHotKeysElevate.vbs"
+
+rem The task runs with the highest available privileges, so deleting it requires the same; re-launch elevated
+net session >nul 2>&1
+
+if not errorlevel 1 goto :elevated
+
+echo Requesting administrator privileges to remove the scheduled task...
+
+rem Windows offers no built-in way to raise a consent prompt from a batch file, so hand the re-launch to the shell
+> "%ELEVATION_SCRIPT%" echo CreateObject("Shell.Application").ShellExecute "%~f0", "", "", "runas", 1
+
+cscript //nologo "%ELEVATION_SCRIPT%"
+
+del "%ELEVATION_SCRIPT%" >nul 2>&1
+
+exit /b 0
+
+:elevated
+
+echo.
+echo Display Hot Keys - Portable Uninstall
+echo.
+
+rem Close the running app first, since it re-registers the task on exit and holds the settings file open
+tasklist /fi "imagename eq %APP_EXE%" 2>nul | findstr /i /c:"%APP_EXE%" >nul
+
+if errorlevel 1 goto :queryTask
+
+taskkill /f /t /im "%APP_EXE%" >nul 2>&1
+
+echo Closed the running application.
+
+:queryTask
+
+rem The query reports a missing task on stderr yet still exits zero, so detect it by the absence of stdout instead
+schtasks /Query /TN "%APP_NAME%" 2>nul | findstr /b /l /i "TaskName" >nul
+
+if errorlevel 1 goto :taskMissing
+
+schtasks /Delete /TN "%APP_NAME%" /F >nul 2>&1
+
+rem The delete also exits zero when it fails, so confirm removal by querying for the task again
+schtasks /Query /TN "%APP_NAME%" 2>nul | findstr /b /l /i "TaskName" >nul
+
+if not errorlevel 1 goto :taskFailed
+
+echo Removed the "%APP_NAME%" scheduled task.
+
+goto :startupFile
+
+:taskFailed
+
+echo Could not remove the "%APP_NAME%" scheduled task. Remove it in Task Scheduler.
+
+goto :startupFile
+
+:taskMissing
+
+echo No "%APP_NAME%" scheduled task is registered.
+
+:startupFile
+
+rem The app falls back to a startup folder batch file when the task cannot be registered, so clear that too
+if not exist "%STARTUP_FILE%" goto :settings
+
+del /f /q "%STARTUP_FILE%" >nul 2>&1
+
+if not exist "%STARTUP_FILE%" echo Removed the startup folder entry.
+
+:settings
+
+if not exist "%SETTINGS_FILE%" goto :settingsMissing
+
+echo.
+echo Saved settings were found at:
+echo   %SETTINGS_FILE%
+echo.
+echo Keeping them preserves saved slots.
+echo.
+
+set "DELETE_SETTINGS="
+set /p "DELETE_SETTINGS=Do you also want to delete the saved settings? [Y/N]: "
+
+if /i not "%DELETE_SETTINGS%"=="y" goto :settingsKept
+
+del /f /q "%SETTINGS_FILE%" >nul 2>&1
+
+rem The app leaves its single instance lock file behind on exit, which would otherwise keep the folder populated
+del /f /q "%LOCK_FILE%" >nul 2>&1
+
+rem Leave the folder alone unless the removed files were the only things in it
+rd "%SETTINGS_DIR%" >nul 2>&1
+
+echo Deleted the saved settings.
+
+goto :done
+
+:settingsKept
+
+echo Kept the saved settings.
+
+goto :done
+
+:settingsMissing
+
+echo No saved settings were found.
+
+:done
+
+echo.
+echo Cleanup complete. You can now delete the Display Hot Keys folder.
+echo.
+
+pause
+
+endlocal
+
+exit /b 0

--- a/jni/DisplayEventNotifier.rc
+++ b/jni/DisplayEventNotifier.rc
@@ -1,7 +1,7 @@
 #include <windows.h>
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,0,0,0
+ FILEVERSION 1,0,3,0
  PRODUCTVERSION 1,0,3,0
  FILEFLAGSMASK 0x3fL
  FILEFLAGS 0x0L
@@ -14,7 +14,7 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription", "Notify settings changes for displays"
-            VALUE "FileVersion", "1.0.0.0"
+            VALUE "FileVersion", "1.0.3.0"
             VALUE "ProductName", "DisplayEventNotifier"
             VALUE "ProductVersion", "1.0.3.0"
             VALUE "LegalCopyright", "Copyright © 2026 Jonathan R. Miller"

--- a/jni/DisplayHotKeysLauncher.cpp
+++ b/jni/DisplayHotKeysLauncher.cpp
@@ -1,0 +1,246 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright © 2026 Jonathan R. Miller
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the “Software”), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <comdef.h>
+#include <shellapi.h>
+#include <string>
+#include <taskschd.h>
+#include <wchar.h>
+#include <windows.h>
+
+using namespace std;
+
+wstring getLaunchDirectory();
+bool runRegisteredTask(const wstring &appExePath);
+bool taskRunsExecutable(IRegisteredTask *registeredTask, const wstring &appExePath);
+bool startExecutableDirectly(const wstring &appExePath);
+
+/**
+ * Name of the task that starts the application.
+ */
+static const wchar_t *TASK_NAME = L"Display Hot Keys";
+
+/**
+ * File name of the application executable that this launcher starts.
+ */
+static const wchar_t *APP_EXE_NAME = L"DisplayHotKeys.exe";
+
+/**
+ * Exit code reported when the application was started.
+ */
+static const int EXIT_STARTED = 0;
+
+/**
+ * Exit code reported when neither start path could launch the application.
+ */
+static const int EXIT_NOT_STARTED = 1;
+
+/**
+ * Entry point that starts the application through its registered task so it gains elevated rights without a consent
+ * prompt after the first launch, falling back to starting the executable directly when no usable task is registered.
+ *
+ * @return Zero when the application was started, or one when neither start path succeeded
+ */
+int WINAPI wWinMain(HINSTANCE, HINSTANCE, PWSTR, int) {
+    wstring launchDirectory = getLaunchDirectory();
+
+    if (launchDirectory.empty()) {
+        return EXIT_NOT_STARTED;
+    }
+
+    wstring appExePath = launchDirectory + L"\\" + APP_EXE_NAME;
+
+    if (runRegisteredTask(appExePath)) {
+        return EXIT_STARTED;
+    }
+
+    /*
+     * No task is registered yet, it points at a different copy, or the scheduler refused to start it. Starting the
+     * executable directly elevates through its own manifest, which costs one consent prompt and lets the application
+     * register the task, so later launches go through the prompt-free path above
+     */
+    return startExecutableDirectly(appExePath) ? EXIT_STARTED : EXIT_NOT_STARTED;
+}
+
+/**
+ * Resolves the directory holding this launcher, which is also where the application executable sits.
+ *
+ * @return The launcher's directory without a trailing separator, or an empty string when it cannot be resolved
+ */
+wstring getLaunchDirectory() {
+    wchar_t modulePath[MAX_PATH];
+    DWORD pathLength = GetModuleFileNameW(nullptr, modulePath, MAX_PATH);
+
+    // A truncated path would silently resolve to the wrong executable, so treat a full buffer as a failure
+    if (pathLength == 0 || pathLength == MAX_PATH) {
+        return wstring();
+    }
+
+    wstring fullPath(modulePath, pathLength);
+    size_t separatorIndex = fullPath.find_last_of(L'\\');
+
+    if (separatorIndex == wstring::npos) {
+        return wstring();
+    }
+
+    return fullPath.substr(0, separatorIndex);
+}
+
+/**
+ * Starts the registered task when it drives this copy of the application. The scheduler builds the elevated token
+ * itself, so the application starts with the rights it needs and no consent prompt appears.
+ *
+ * @param appExePath
+ *            - The full path of the application executable the task must run
+ *
+ * @return True if the task was started, false otherwise
+ */
+bool runRegisteredTask(const wstring &appExePath) {
+    if (FAILED(CoInitializeEx(nullptr, COINIT_MULTITHREADED))) {
+        return false;
+    }
+
+    ITaskService *taskService = nullptr;
+    IRegisteredTask *registeredTask = nullptr;
+    ITaskFolder *rootFolder = nullptr;
+    IRunningTask *runningTask = nullptr;
+    BSTR rootFolderPath = SysAllocString(L"\\");
+    BSTR taskName = SysAllocString(TASK_NAME);
+    bool taskStarted = false;
+
+    /*
+     * An empty variant serves as both the connect credentials, which target the local machine as the current user, and
+     * the run argument list. It holds no allocation, so it needs no matching clear
+     */
+    VARIANT emptyArgument;
+    VariantInit(&emptyArgument);
+
+    if (rootFolderPath != nullptr && taskName != nullptr &&
+        SUCCEEDED(CoCreateInstance(CLSID_TaskScheduler, nullptr, CLSCTX_INPROC_SERVER, IID_ITaskService,
+                                   reinterpret_cast<void **>(&taskService))) &&
+        SUCCEEDED(taskService->Connect(emptyArgument, emptyArgument, emptyArgument, emptyArgument)) &&
+        SUCCEEDED(taskService->GetFolder(rootFolderPath, &rootFolder)) &&
+        SUCCEEDED(rootFolder->GetTask(taskName, &registeredTask)) && taskRunsExecutable(registeredTask, appExePath)) {
+        taskStarted = SUCCEEDED(registeredTask->Run(emptyArgument, &runningTask));
+    }
+
+    SysFreeString(rootFolderPath);
+    SysFreeString(taskName);
+
+    if (runningTask != nullptr) {
+        runningTask->Release();
+    }
+
+    if (registeredTask != nullptr) {
+        registeredTask->Release();
+    }
+
+    if (rootFolder != nullptr) {
+        rootFolder->Release();
+    }
+
+    if (taskService != nullptr) {
+        taskService->Release();
+    }
+
+    CoUninitialize();
+
+    return taskStarted;
+}
+
+/**
+ * Determines whether the registered task runs the given executable. A portable copy can move or be duplicated, which
+ * leaves a task pointing at a different folder that must not be started in this copy's place.
+ *
+ * @param registeredTask
+ *            - The registered task to inspect
+ * @param appExePath
+ *            - The full path of the application executable the task must run
+ *
+ * @return True if the task's first action runs the given executable, false otherwise
+ */
+bool taskRunsExecutable(IRegisteredTask *registeredTask, const wstring &appExePath) {
+    ITaskDefinition *taskDefinition = nullptr;
+    IActionCollection *actions = nullptr;
+    IAction *action = nullptr;
+    IExecAction *execAction = nullptr;
+    BSTR taskExePath = nullptr;
+    bool pathsMatch = false;
+
+    if (SUCCEEDED(registeredTask->get_Definition(&taskDefinition)) &&
+        SUCCEEDED(taskDefinition->get_Actions(&actions)) && SUCCEEDED(actions->get_Item(1, &action)) &&
+        SUCCEEDED(action->QueryInterface(IID_IExecAction, reinterpret_cast<void **>(&execAction))) &&
+        SUCCEEDED(execAction->get_Path(&taskExePath)) && taskExePath != nullptr) {
+        // Windows paths are case insensitive, so compare without regard to case
+        pathsMatch = _wcsicmp(taskExePath, appExePath.c_str()) == 0;
+    }
+
+    if (taskExePath != nullptr) {
+        SysFreeString(taskExePath);
+    }
+
+    if (execAction != nullptr) {
+        execAction->Release();
+    }
+
+    if (action != nullptr) {
+        action->Release();
+    }
+
+    if (actions != nullptr) {
+        actions->Release();
+    }
+
+    if (taskDefinition != nullptr) {
+        taskDefinition->Release();
+    }
+
+    return pathsMatch;
+}
+
+/**
+ * Starts the application executable directly, letting its own manifest raise it to the rights it needs.
+ *
+ * @param appExePath
+ *            - The full path of the application executable to start
+ *
+ * @return True if the executable was started, false otherwise
+ */
+bool startExecutableDirectly(const wstring &appExePath) {
+    SHELLEXECUTEINFOW executeInfo = {};
+    executeInfo.cbSize = sizeof(executeInfo);
+    executeInfo.fMask = SEE_MASK_NOCLOSEPROCESS;
+    executeInfo.lpVerb = L"open";
+    executeInfo.lpFile = appExePath.c_str();
+    executeInfo.nShow = SW_SHOWNORMAL;
+
+    /*
+     * ShellExecuteEx honors the target's requested execution level, unlike CreateProcess, which fails outright when the
+     * manifest asks for elevation this launcher does not hold
+     */
+    if (!ShellExecuteExW(&executeInfo)) {
+        return false;
+    }
+
+    if (executeInfo.hProcess != nullptr) {
+        CloseHandle(executeInfo.hProcess);
+    }
+
+    return true;
+}

--- a/jni/DisplayHotKeysLauncher.manifest
+++ b/jni/DisplayHotKeysLauncher.manifest
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+    <application xmlns="urn:schemas-microsoft-com:asm.v3">
+        <windowsSettings xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+            <dpiAwareness>PerMonitorV2</dpiAwareness>
+        </windowsSettings>
+    </application>
+</assembly>

--- a/jni/DisplayHotKeysLauncher.rc
+++ b/jni/DisplayHotKeysLauncher.rc
@@ -1,0 +1,32 @@
+#include <windows.h>
+
+1 RT_MANIFEST "DisplayHotKeysLauncher.manifest"
+
+1 ICON "../distribution/dhk.ico"
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 4,0,5,0
+ PRODUCTVERSION 4,0,5,0
+ FILEFLAGSMASK 0x3fL
+ FILEFLAGS 0x0L
+ FILEOS VOS_NT_WINDOWS32
+ FILETYPE VFT_APP
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "FileDescription", "Launches Display Hot Keys"
+            VALUE "FileVersion", "4.0.5.0"
+            VALUE "ProductName", "Display Hot Keys"
+            VALUE "ProductVersion", "4.0.5.0"
+            VALUE "LegalCopyright", "Copyright © 2026 Jonathan R. Miller"
+            VALUE "OriginalFilename", "DisplayHotKeysLauncher.exe"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END

--- a/jni/GetDisplay.rc
+++ b/jni/GetDisplay.rc
@@ -1,7 +1,7 @@
 #include <windows.h>
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,0,0,0
+ FILEVERSION 2,1,0,0
  PRODUCTVERSION 2,1,0,0
  FILEFLAGSMASK 0x3fL
  FILEFLAGS 0x0L
@@ -14,7 +14,7 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription", "Retrieve settings for displays"
-            VALUE "FileVersion", "1.0.0.0"
+            VALUE "FileVersion", "2.1.0.0"
             VALUE "ProductName", "GetDisplay"
             VALUE "ProductVersion", "2.1.0.0"
             VALUE "LegalCopyright", "Copyright © 2026 Jonathan R. Miller"

--- a/jni/SetDisplay.rc
+++ b/jni/SetDisplay.rc
@@ -1,7 +1,7 @@
 #include <windows.h>
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,0,0,0
+ FILEVERSION 2,1,0,0
  PRODUCTVERSION 2,1,0,0
  FILEFLAGSMASK 0x3fL
  FILEFLAGS 0x0L
@@ -14,7 +14,7 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription", "Apply settings for displays"
-            VALUE "FileVersion", "1.0.0.0"
+            VALUE "FileVersion", "2.1.0.0"
             VALUE "ProductName", "SetDisplay"
             VALUE "ProductVersion", "2.1.0.0"
             VALUE "LegalCopyright", "Copyright © 2026 Jonathan R. Miller"

--- a/makefile
+++ b/makefile
@@ -11,6 +11,7 @@ GCCVER := $(shell $(CXX) -dumpfullversion)
 COMMON_DEFS = -DUNICODE -D_UNICODE -D_WIN32 -D_WINDOWS -DWIN32_LEAN_AND_MEAN -D_WIN32_WINNT=0x0A00 -DWINVER=0x0A00
 INCLUDES = -I"$(JAVA_HOME)\include" -I"$(JAVA_HOME)\include\win32" -I"$(MINGW)\include" -I"$(MINGW)\include\c++\$(GCCVER)" -I"$(MINGW)\lib\gcc\x86_64-w64-mingw32\$(GCCVER)\include" -I"$(MINGW)\lib\gcc\x86_64-w64-mingw32\$(GCCVER)\include-fixed"
 LDFLAGS = -shared -static
+LAUNCHER_LDFLAGS = -static -mwindows -municode -s -Wl,--gc-sections
 
 clean:
 	rm -f jni/com_dhk_io_GetDisplay.h
@@ -19,6 +20,7 @@ clean:
 	rm -f *.res.o
 	rm -f *.dll
 	rm -f distribution/GetDisplay.dll distribution/SetDisplay.dll distribution/DisplayEventNotifier.dll
+	rm -f distribution/DisplayHotKeysLauncher.exe
 
 header:
 	mkdir -p jni
@@ -45,8 +47,22 @@ dll:
 	$(WINDRES) $(RCFLAGS) jni/DisplayEventNotifier.rc DisplayEventNotifier.res.o
 	$(CXX) $(CXXSTD) $(OPT) jni/com_dhk_io_DisplayEventNotifier.cpp jni/DisplayConfig.cpp DisplayEventNotifier.res.o $(COMMON_DEFS) $(INCLUDES) $(TOOLCHAIN_FLAGS) $(LDFLAGS) -o DisplayEventNotifier.dll
 
+	# The resources are linked in by now, so drop the intermediates instead of leaving them in the project root
+	rm -f GetDisplay.res.o SetDisplay.res.o DisplayEventNotifier.res.o
+
 	mkdir -p distribution
 	cp -f GetDisplay.dll SetDisplay.dll DisplayEventNotifier.dll distribution/
 
+launcher:
+	# Build the unelevated launcher that starts the elevated app through its scheduled task
+	# The resource script embeds the asInvoker manifest, so the launcher itself never triggers elevation
+	mkdir -p distribution
 
-all: clean header dll
+	# Unlike the libraries, nothing loads this from the project root, so link it straight into the packaging folder
+	$(WINDRES) $(RCFLAGS) jni/DisplayHotKeysLauncher.rc DisplayHotKeysLauncher.res.o
+	$(CXX) $(CXXSTD) $(OPT) -ffunction-sections -fdata-sections jni/DisplayHotKeysLauncher.cpp DisplayHotKeysLauncher.res.o $(COMMON_DEFS) $(INCLUDES) $(TOOLCHAIN_FLAGS) $(LAUNCHER_LDFLAGS) -lole32 -loleaut32 -ltaskschd -lshell32 -luuid -o distribution/DisplayHotKeysLauncher.exe
+
+	# The resource is linked in by now, so drop the intermediate instead of leaving it in the project root
+	rm -f DisplayHotKeysLauncher.res.o
+
+all: clean header dll launcher

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>DisplayHotKeys</groupId>
     <artifactId>DisplayHotKeys</artifactId>
-    <version>4.0.4</version>
+    <version>4.0.5</version>
     <name>DisplayHotKeys</name>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/dhk/controller/DhkController.java
+++ b/src/main/java/com/dhk/controller/DhkController.java
@@ -139,7 +139,11 @@ public class DhkController implements IController {
 
         // Attach the new dispatch listener; the persistent held-key tracker remains attached across re-inits
         keyboardHook.addKeyListener(hotKeysController);
-        view.getFrame().setExtendedState(frameState);
+
+        // A frame held back for the tray is handed off by the window controller, so leave its state alone
+        if (!view.isStartMinimizedToTray()) {
+            view.getFrame().setExtendedState(frameState);
+        }
     }
 
     @Override

--- a/src/main/java/com/dhk/controller/WindowController.java
+++ b/src/main/java/com/dhk/controller/WindowController.java
@@ -57,6 +57,14 @@ public class WindowController implements IController, WindowListener {
     @Override
     public void initController() {
         minimizeToTray = new MinimizeToTray(model, view, "/tray_icon.png");
+
+        /*
+         * A frame held back for the tray is never shown, so it raises no iconified event to hand it off. Bring the tray
+         * up here instead, since the tray menu wires its own callbacks and needs nothing from the window listener
+         */
+        if (view.isStartMinimizedToTray()) {
+            minimizeToTray.execute();
+        }
     }
 
     @Override

--- a/src/main/java/com/dhk/io/RunOnStartupManager.java
+++ b/src/main/java/com/dhk/io/RunOnStartupManager.java
@@ -23,12 +23,13 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
 
+import com.dhk.utility.LaunchTaskUtility;
+
 /**
- * Gets the application's path and uses it to create or destroy a batch file that will run the application on Windows
- * login.
+ * Enables or disables running the application upon login, preferring the logon trigger of the task that starts it
+ * elevated and falling back to a startup folder batch file when that task cannot be registered.
  *
  * @author Jonathan R. Miller
  */
@@ -38,7 +39,6 @@ public class RunOnStartupManager {
     private String runOnStartupFileName;
     private String runOnStartupFilePath;
     private File runOnStartupFile;
-    private String appExePath;
 
     /**
      * Constructor for the {@link RunOnStartupManager} class.
@@ -50,19 +50,60 @@ public class RunOnStartupManager {
         runOnStartupFileName = "StartDisplayHotKeys.bat";
         runOnStartupFilePath = startupPath + runOnStartupFileName;
         runOnStartupFile = new File(runOnStartupFilePath);
+    }
 
-        // The jpackage launcher exposes its own executable path here; fall back to the code source when unpackaged
-        appExePath = System.getProperty("jpackage.app-path");
+    /**
+     * Enables the logon trigger of the task so the application starts upon login.
+     */
+    public void addToStartup() {
+        setRunOnStartup(true);
+    }
 
-        if (appExePath == null) {
-            appExePath = deriveExePathFromCodeSource();
+    /**
+     * Disables the logon trigger of the task so it no longer starts the application on login. The task itself stays
+     * registered so the launcher can start the application elevated without a consent prompt after the first launch.
+     */
+    public void removeFromStartup() {
+        setRunOnStartup(false);
+    }
+
+    /**
+     * Applies the wanted run on startup state through the task's logon trigger, falling back to the startup folder when
+     * the task cannot be registered.
+     *
+     * @param runOnStartup
+     *            - Whether the application should start upon login
+     */
+    private void setRunOnStartup(boolean runOnStartup) {
+        if (LaunchTaskUtility.registerTask(runOnStartup)) {
+            removeStartupFile();
+
+            return;
         }
+
+        /*
+         * Registering the task needs administrator rights, which a standard account never has. Fall back to the startup
+         * folder batch file so the setting still works there, at the cost of the login console flash
+         */
+        if (runOnStartup) {
+            addStartupFile();
+
+            return;
+        }
+
+        removeStartupFile();
     }
 
     /**
      * Adds a batch file to the user's startup folder that will execute this application upon login.
      */
-    public void addToStartup() {
+    private void addStartupFile() {
+        String appExePath = LaunchTaskUtility.getAppExePath();
+
+        if (appExePath == null) {
+            return;
+        }
+
         try {
             PrintWriter startupFileWriter = new PrintWriter(runOnStartupFile);
 
@@ -78,34 +119,12 @@ public class RunOnStartupManager {
     /**
      * Removes the run on startup file from the user's startup folder.
      */
-    public void removeFromStartup() {
+    private void removeStartupFile() {
         try {
             Files.deleteIfExists(runOnStartupFile.toPath());
         } catch (IOException e) {
             e.printStackTrace();
         }
-    }
-
-    /**
-     * Derives the launcher executable path from the running code source for unpackaged development runs.
-     *
-     * @return The derived executable path, or null if the code source location cannot be resolved
-     */
-    private String deriveExePathFromCodeSource() {
-        File jarFile = null;
-
-        try {
-            jarFile = new File(
-                    RunOnStartupManager.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath());
-        } catch (URISyntaxException e) {
-            e.printStackTrace();
-        }
-
-        if (jarFile == null) {
-            return null;
-        }
-
-        return jarFile.getPath().replaceAll(".jar", ".exe");
     }
 
 }

--- a/src/main/java/com/dhk/io/SingleInstanceLock.java
+++ b/src/main/java/com/dhk/io/SingleInstanceLock.java
@@ -81,7 +81,8 @@ public class SingleInstanceLock {
     }
 
     /**
-     * Releases the exclusive lock and closes the lock file resources.
+     * Releases the exclusive lock, closes the lock file resources, and deletes the lock file so it does not linger in
+     * the user's documents folder after the application exits.
      */
     private void release() {
         try {
@@ -98,6 +99,8 @@ public class SingleInstanceLock {
             }
         } catch (IOException e) {
             e.printStackTrace();
+        } finally {
+            new File(LOCK_FILE_PATH).delete();
         }
     }
 

--- a/src/main/java/com/dhk/main/DhkDriver.java
+++ b/src/main/java/com/dhk/main/DhkDriver.java
@@ -75,9 +75,18 @@ public class DhkDriver {
 
         /*
          * Register the task that runs this application elevated, whether or not it should start on login, so the
-         * launcher can start it without a consent prompt after the first launch
+         * launcher can start it without a consent prompt after the first launch. Registration shells out to the task
+         * command line utility, which costs seconds, so it runs off the startup path where nothing waits on it
          */
-        LaunchTaskUtility.registerTask(settingsMgr.getIniRunOnStartup());
+        Thread taskRegistration = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                LaunchTaskUtility.registerTask(settingsMgr.getIniRunOnStartup());
+            }
+        });
+
+        taskRegistration.setDaemon(true);
+        taskRegistration.start();
 
         SwingUtilities.invokeLater(new Runnable() {
             @Override

--- a/src/main/java/com/dhk/main/DhkDriver.java
+++ b/src/main/java/com/dhk/main/DhkDriver.java
@@ -23,11 +23,11 @@ import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
 
 import com.dhk.controller.DhkController;
-import com.dhk.io.RunOnStartupManager;
 import com.dhk.io.SettingsManager;
 import com.dhk.io.SingleInstanceLock;
 import com.dhk.model.DhkModel;
 import com.dhk.theme.ThemeUpdater;
+import com.dhk.utility.LaunchTaskUtility;
 import com.dhk.view.AlreadyRunningDialog;
 import com.dhk.view.DhkView;
 
@@ -73,13 +73,11 @@ public class DhkDriver {
         SettingsManager settingsMgr = new SettingsManager();
         settingsMgr.initSettingsManager();
 
-        RunOnStartupManager runOnStartupManager = new RunOnStartupManager();
-
-        if (settingsMgr.getIniRunOnStartup()) {
-            runOnStartupManager.addToStartup();
-        } else {
-            runOnStartupManager.removeFromStartup();
-        }
+        /*
+         * Register the task that runs this application elevated, whether or not it should start on login, so the
+         * launcher can start it without a consent prompt after the first launch
+         */
+        LaunchTaskUtility.registerTask(settingsMgr.getIniRunOnStartup());
 
         SwingUtilities.invokeLater(new Runnable() {
             @Override

--- a/src/main/java/com/dhk/utility/LaunchTaskUtility.java
+++ b/src/main/java/com/dhk/utility/LaunchTaskUtility.java
@@ -46,6 +46,12 @@ public class LaunchTaskUtility {
     private static final int TASK_COMMAND_SUCCESS = 0;
 
     /**
+     * Instance policy of the task, which must start a second instance so it reaches the single-instance check and
+     * reports that the application is already running. Suppressing it here would drop the launch silently instead.
+     */
+    private static final String MULTIPLE_INSTANCES_POLICY = "Parallel";
+
+    /**
      * Little endian UTF-16 byte order mark that must precede a task definition.
      */
     private static final byte[] BYTE_ORDER_MARK = {(byte) 0xFF, (byte) 0xFE};
@@ -98,14 +104,14 @@ public class LaunchTaskUtility {
     }
 
     /**
-     * Determines whether the task is registered, points at the running executable, and already has the wanted logon
-     * trigger state. A portable copy can move between launches, which leaves a stale task that would silently fail to
-     * start.
+     * Determines whether the task is registered and already matches the running executable, the wanted logon trigger
+     * state, and the wanted instance policy. A portable copy can move between launches, which leaves a stale task that
+     * would silently fail to start.
      *
      * @param runOnStartup
      *            - The wanted logon trigger state
      *
-     * @return True if the registered task matches the current executable and trigger state, false otherwise
+     * @return True if the registered task matches the current executable, trigger state, and policy, false otherwise
      */
     private static boolean isTaskCurrent(boolean runOnStartup) {
         String taskXml = queryTaskXml();
@@ -115,6 +121,11 @@ public class LaunchTaskUtility {
         }
 
         if (!taskXml.contains("<Command>" + escapeXml(APP_EXE_PATH) + "</Command>")) {
+            return false;
+        }
+
+        // A task registered by an earlier version suppresses a second instance, so rewrite it when the policy is stale
+        if (!taskXml.contains("<MultipleInstancesPolicy>" + MULTIPLE_INSTANCES_POLICY + "</MultipleInstancesPolicy>")) {
             return false;
         }
 
@@ -257,7 +268,8 @@ public class LaunchTaskUtility {
         taskDefinition.append("    </Principal>\n");
         taskDefinition.append("  </Principals>\n");
         taskDefinition.append("  <Settings>\n");
-        taskDefinition.append("    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>\n");
+        taskDefinition
+                .append("    <MultipleInstancesPolicy>" + MULTIPLE_INSTANCES_POLICY + "</MultipleInstancesPolicy>\n");
         taskDefinition.append("    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>\n");
         taskDefinition.append("    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>\n");
         taskDefinition.append("    <AllowHardTerminate>false</AllowHardTerminate>\n");

--- a/src/main/java/com/dhk/utility/LaunchTaskUtility.java
+++ b/src/main/java/com/dhk/utility/LaunchTaskUtility.java
@@ -1,0 +1,371 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright © 2026 Jonathan R. Miller
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the “Software”), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+package com.dhk.utility;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Registers the task that runs this application with the highest available privileges, so the launcher can start the
+ * application elevated without a consent prompt after the first launch. The task's logon trigger carries the run on
+ * startup state.
+ *
+ * @author Jonathan R. Miller
+ */
+public class LaunchTaskUtility {
+
+    /**
+     * Name of the task that starts the application.
+     */
+    private static final String TASK_NAME = "Display Hot Keys";
+
+    /**
+     * Exit code returned by the task command line utility when a command succeeds.
+     */
+    private static final int TASK_COMMAND_SUCCESS = 0;
+
+    /**
+     * Little endian UTF-16 byte order mark that must precede a task definition.
+     */
+    private static final byte[] BYTE_ORDER_MARK = {(byte) 0xFF, (byte) 0xFE};
+
+    /**
+     * File extension that a derived path must carry to be a runnable task command.
+     */
+    private static final String EXE_EXTENSION = ".exe";
+
+    /**
+     * Path of the executable the task runs, resolved once because it cannot change while the application runs.
+     */
+    private static final String APP_EXE_PATH = resolveAppExePath();
+
+    /**
+     * Default constructor for the {@link LaunchTaskUtility} class.
+     */
+    public LaunchTaskUtility() {
+    }
+
+    /**
+     * Registers the task when it is missing or no longer matches this copy of the application, so the launcher can
+     * start the application elevated without a consent prompt after the first launch.
+     *
+     * @param runOnStartup
+     *            - Whether the task's logon trigger should be enabled
+     *
+     * @return True if the task is registered and current, false otherwise
+     */
+    public static boolean registerTask(boolean runOnStartup) {
+        if (APP_EXE_PATH == null) {
+            return false;
+        }
+
+        // Re-registering on every launch would spawn a process each time, so only do so when the task is out of date
+        if (isTaskCurrent(runOnStartup)) {
+            return true;
+        }
+
+        return writeTask(runOnStartup);
+    }
+
+    /**
+     * Gets the path of the executable the task runs, which is also what starts the application upon login.
+     *
+     * @return The application executable path, or null when it does not resolve to an executable
+     */
+    public static String getAppExePath() {
+        return APP_EXE_PATH;
+    }
+
+    /**
+     * Determines whether the task is registered, points at the running executable, and already has the wanted logon
+     * trigger state. A portable copy can move between launches, which leaves a stale task that would silently fail to
+     * start.
+     *
+     * @param runOnStartup
+     *            - The wanted logon trigger state
+     *
+     * @return True if the registered task matches the current executable and trigger state, false otherwise
+     */
+    private static boolean isTaskCurrent(boolean runOnStartup) {
+        String taskXml = queryTaskXml();
+
+        if (taskXml == null) {
+            return false;
+        }
+
+        if (!taskXml.contains("<Command>" + escapeXml(APP_EXE_PATH) + "</Command>")) {
+            return false;
+        }
+
+        /*
+         * The scheduler rewrites the definition it stores, collapsing an enabled trigger to a self-closing element that
+         * omits the default, so detect the disabled state and infer the enabled one rather than matching what was
+         * written
+         */
+        boolean triggerDisabled = taskXml.contains("<Enabled>false</Enabled>");
+
+        return triggerDisabled != runOnStartup;
+    }
+
+    /**
+     * Reads the registered task definition.
+     *
+     * @return The task definition XML, or null when the task is not registered
+     */
+    private static String queryTaskXml() {
+        ProcessBuilder taskQueryBuilder = new ProcessBuilder("schtasks", "/Query", "/TN", TASK_NAME, "/XML");
+        taskQueryBuilder.redirectErrorStream(true);
+
+        try {
+            Process taskQuery = taskQueryBuilder.start();
+            String taskXml = new String(taskQuery.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+
+            if (taskQuery.waitFor() != TASK_COMMAND_SUCCESS) {
+                return null;
+            }
+
+            return taskXml;
+        } catch (IOException e) {
+            return null;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+
+            return null;
+        }
+    }
+
+    /**
+     * Writes the task from a task definition file, replacing any existing registration.
+     *
+     * @param runOnStartup
+     *            - Whether the task's logon trigger should be enabled
+     *
+     * @return True if the task was registered, false when registration failed
+     */
+    private static boolean writeTask(boolean runOnStartup) {
+        Path taskDefinitionFile = null;
+
+        try {
+            taskDefinitionFile = Files.createTempFile("DisplayHotKeys", ".xml");
+
+            /*
+             * The task command line utility only reads task definitions encoded as little endian UTF-16, and it rejects
+             * one lacking a byte order mark as malformed, so write the mark ahead of the definition
+             */
+            byte[] definitionBytes = buildTaskDefinition(runOnStartup).getBytes(StandardCharsets.UTF_16LE);
+            byte[] taskDefinitionBytes = new byte[BYTE_ORDER_MARK.length + definitionBytes.length];
+
+            System.arraycopy(BYTE_ORDER_MARK, 0, taskDefinitionBytes, 0, BYTE_ORDER_MARK.length);
+            System.arraycopy(definitionBytes, 0, taskDefinitionBytes, BYTE_ORDER_MARK.length, definitionBytes.length);
+
+            Files.write(taskDefinitionFile, taskDefinitionBytes);
+
+            return runTaskCommand("/Create", "/TN", TASK_NAME, "/XML", taskDefinitionFile.toString(), "/F");
+        } catch (IOException e) {
+            return false;
+        } finally {
+            if (taskDefinitionFile != null) {
+                try {
+                    Files.deleteIfExists(taskDefinitionFile);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+    /**
+     * Runs the task command line utility with the given arguments.
+     *
+     * @param taskArguments
+     *            - The arguments to pass to the task command line utility
+     *
+     * @return True if the command succeeded, false otherwise
+     */
+    private static boolean runTaskCommand(String... taskArguments) {
+        String[] taskCommand = new String[taskArguments.length + 1];
+        taskCommand[0] = "schtasks";
+
+        for (int argumentIndex = 0; argumentIndex < taskArguments.length; argumentIndex++) {
+            taskCommand[argumentIndex + 1] = taskArguments[argumentIndex];
+        }
+
+        ProcessBuilder taskCommandBuilder = new ProcessBuilder(taskCommand);
+        taskCommandBuilder.redirectErrorStream(true);
+
+        try {
+            Process taskProcess = taskCommandBuilder.start();
+
+            // Drain the output so the utility never blocks on a full pipe
+            taskProcess.getInputStream().readAllBytes();
+
+            return taskProcess.waitFor() == TASK_COMMAND_SUCCESS;
+        } catch (IOException e) {
+            return false;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+
+            return false;
+        }
+    }
+
+    /**
+     * Builds the task definition. The command line utility's own flags force settings that would stop the application
+     * from starting on battery power and would terminate it when a laptop is unplugged, so the definition is supplied
+     * as XML instead to turn those off.
+     *
+     * @param runOnStartup
+     *            - Whether the logon trigger should be enabled
+     *
+     * @return The task definition XML
+     */
+    private static String buildTaskDefinition(boolean runOnStartup) {
+        StringBuilder taskDefinition = new StringBuilder();
+
+        taskDefinition.append("<?xml version=\"1.0\" encoding=\"UTF-16\"?>\n");
+        taskDefinition.append("<Task version=\"1.2\" ");
+        taskDefinition.append("xmlns=\"http://schemas.microsoft.com/windows/2004/02/mit/task\">\n");
+        taskDefinition.append("  <RegistrationInfo>\n");
+        taskDefinition.append("    <Author>Jonathan R. Miller</Author>\n");
+        taskDefinition.append("    <Description>Launches Display Hot Keys</Description>\n");
+        taskDefinition.append("  </RegistrationInfo>\n");
+        taskDefinition.append("  <Principals>\n");
+        taskDefinition.append("    <Principal id=\"Author\">\n");
+        taskDefinition.append("      <LogonType>InteractiveToken</LogonType>\n");
+        taskDefinition.append("      <RunLevel>HighestAvailable</RunLevel>\n");
+        taskDefinition.append("    </Principal>\n");
+        taskDefinition.append("  </Principals>\n");
+        taskDefinition.append("  <Settings>\n");
+        taskDefinition.append("    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>\n");
+        taskDefinition.append("    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>\n");
+        taskDefinition.append("    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>\n");
+        taskDefinition.append("    <AllowHardTerminate>false</AllowHardTerminate>\n");
+        taskDefinition.append("    <StartWhenAvailable>false</StartWhenAvailable>\n");
+        taskDefinition.append("    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>\n");
+        taskDefinition.append("    <IdleSettings>\n");
+        taskDefinition.append("      <StopOnIdleEnd>false</StopOnIdleEnd>\n");
+        taskDefinition.append("      <RestartOnIdle>false</RestartOnIdle>\n");
+        taskDefinition.append("    </IdleSettings>\n");
+        taskDefinition.append("    <AllowStartOnDemand>true</AllowStartOnDemand>\n");
+        taskDefinition.append("    <Enabled>true</Enabled>\n");
+        taskDefinition.append("    <Hidden>false</Hidden>\n");
+        taskDefinition.append("    <RunOnlyIfIdle>false</RunOnlyIfIdle>\n");
+        taskDefinition.append("    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>\n");
+        taskDefinition.append("    <Priority>7</Priority>\n");
+        taskDefinition.append("  </Settings>\n");
+        taskDefinition.append("  <Triggers>\n");
+        taskDefinition.append(buildLogonTrigger(runOnStartup));
+        taskDefinition.append("  </Triggers>\n");
+        taskDefinition.append("  <Actions Context=\"Author\">\n");
+        taskDefinition.append("    <Exec>\n");
+        taskDefinition.append("      <Command>" + escapeXml(APP_EXE_PATH) + "</Command>\n");
+        taskDefinition.append("    </Exec>\n");
+        taskDefinition.append("  </Actions>\n");
+        taskDefinition.append("</Task>\n");
+
+        return taskDefinition.toString();
+    }
+
+    /**
+     * Builds the logon trigger element. The trigger stays in the definition when the application should not start on
+     * login and is disabled instead, so the task itself survives to keep starting the application elevated.
+     *
+     * @param runOnStartup
+     *            - Whether the logon trigger should be enabled
+     *
+     * @return The logon trigger XML
+     */
+    private static String buildLogonTrigger(boolean runOnStartup) {
+        StringBuilder logonTrigger = new StringBuilder();
+
+        logonTrigger.append("    <LogonTrigger>\n");
+        logonTrigger.append("      <Enabled>" + runOnStartup + "</Enabled>\n");
+        logonTrigger.append("    </LogonTrigger>\n");
+
+        return logonTrigger.toString();
+    }
+
+    /**
+     * Escapes the characters that would otherwise terminate or corrupt the enclosing XML element, since an installation
+     * path may legitimately contain an ampersand.
+     *
+     * @param text
+     *            - The text to escape
+     *
+     * @return The escaped text
+     */
+    private static String escapeXml(String text) {
+        return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+    }
+
+    /**
+     * Resolves the path of the executable that the task runs.
+     *
+     * @return The application executable path, or null if it does not resolve to an executable
+     */
+    private static String resolveAppExePath() {
+        // The jpackage launcher exposes its own executable path here; fall back to the code source when unpackaged
+        String appExePath = System.getProperty("jpackage.app-path");
+
+        if (appExePath != null) {
+            return appExePath;
+        }
+
+        return deriveExePathFromCodeSource();
+    }
+
+    /**
+     * Derives the executable path from the running code source for unpackaged runs.
+     *
+     * @return The derived executable path, or null if the code source does not resolve to an executable
+     */
+    private static String deriveExePathFromCodeSource() {
+        File jarFile = null;
+
+        try {
+            jarFile = new File(
+                    LaunchTaskUtility.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath());
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        }
+
+        if (jarFile == null) {
+            return null;
+        }
+
+        String derivedPath = jarFile.getPath().replaceAll(".jar", ".exe");
+
+        /*
+         * Running from a development environment resolves the code source to a class output directory, which leaves
+         * nothing to replace. The task command line utility accepts a directory without complaint, so registering that
+         * path would yield a task that can never start the application
+         */
+        if (!derivedPath.toLowerCase().endsWith(EXE_EXTENSION)) {
+            return null;
+        }
+
+        return derivedPath;
+    }
+
+}

--- a/src/main/java/com/dhk/view/DhkView.java
+++ b/src/main/java/com/dhk/view/DhkView.java
@@ -102,6 +102,7 @@ public class DhkView implements IView {
     private List<Button> buttons;
     private int previouslySelectedDisplayIndex;
     private int gridYPosForSlotInPanel;
+    private boolean startMinimizedToTray;
 
     private static final int NUM_OF_SLOT_COMPONENTS = 11;
     private static final String[] ORIENTATION_MODES = {"Landscape", "Portrait", "iLandscape", "iPortrait"};
@@ -149,6 +150,14 @@ public class DhkView implements IView {
         int desiredDisplayIndex = (model.getNumOfConnectedDisplays() > 0)
                 ? Math.max(0, Math.min(selectedDisplayIndex, model.getNumOfConnectedDisplays() - 1))
                 : 0;
+
+        /*
+         * Decide the tray handoff before the frame is ever shown, so a frame bound for the tray is never flashed. A
+         * rebuild keeps the frame off screen only when it was already away, so it comes back exactly as the user left
+         * it
+         */
+        boolean previousFrameWasAway = (previousFrame != null) && !previousFrame.isShowing();
+        startMinimizedToTray = model.isMinimizeToTray() && (previousFrame == null || previousFrameWasAway);
 
         // Reset view state used by component initialization
         displayConfig = model.getDisplayConfig();
@@ -212,15 +221,21 @@ public class DhkView implements IView {
 
         /*
          * Make the frame visible after all components are added and the frame is packed. Showing the frame earlier can
-         * cause transient artifacts (ghost copies) during repaint
+         * cause transient artifacts (ghost copies) during repaint. A frame bound for the tray is never shown at all,
+         * since showing and then hiding it flashes an unpainted window for as long as the tray takes to come up
          */
-        newFrame.setVisible(true);
+        if (!startMinimizedToTray) {
+            newFrame.setVisible(true);
 
-        // Grow the frame to absorb any pack shortfall so scroll bars do not appear when the content fits on screen
-        SwingUtilities.invokeLater(() -> FrameUtil.settleScrollBars(newFrame, scrollPane, workingAreaSize));
+            // Grow the frame to absorb any pack shortfall so scroll bars do not appear when the content fits on screen
+            SwingUtilities.invokeLater(() -> FrameUtil.settleScrollBars(newFrame, scrollPane, workingAreaSize));
 
-        // Re-assert the placement after the frame is shown, in case the OS positioned it elsewhere
-        SwingUtilities.invokeLater(() -> FrameUtil.correctLocation(newFrame, previousPlacement));
+            /*
+             * Re-assert the placement after the frame is shown, in case the OS positioned it elsewhere. Both fix-ups
+             * only mean something for a frame on screen, so a frame held back for the tray corrects them when restored
+             */
+            SwingUtilities.invokeLater(() -> FrameUtil.correctLocation(newFrame, previousPlacement));
+        }
 
         // Dispose of the previous frame
         if (previousFrame != null) {
@@ -830,6 +845,15 @@ public class DhkView implements IView {
      */
     public JFrame getFrame() {
         return frame;
+    }
+
+    /**
+     * Gets whether this build left the frame hidden for the tray, which means the tray still has to be brought up.
+     *
+     * @return True if the frame was never shown because it starts minimized to the tray, false otherwise
+     */
+    public boolean isStartMinimizedToTray() {
+        return startMinimizedToTray;
     }
 
     /**


### PR DESCRIPTION
Created a launcher for Display Hot Keys

Created DisplayHotKeysLauncher.cpp, DisplayHotKeysLauncher.rc, and
DisplayHotKeysLauncher.manifest to build an asInvoker launcher that
starts the application through its registered task, so the scheduler
builds the elevated token and no consent prompt appears

Added a direct start fallback in the launcher for when no matching task
is registered yet, since that first elevated launch is what lets the
application register the task

Created LaunchTaskUtility to register the task with the highest
available privileges, comparing the stored definition against the
running executable so a moved portable copy re-registers instead of
silently failing to start

Updated DhkDriver.main to register the task on every launch regardless
of the run on startup setting, so the prompt-free path is available from
the first run onward

Updated RunOnStartupManager to carry the run on startup state on the
task's logon trigger, keeping the startup folder batch file only as a
fallback for accounts that cannot register a task

Removed deriveExePathFromCodeSource from RunOnStartupManager since
LaunchTaskUtility now resolves the executable path

Added a RemoveTask procedure to DisplayHotKeysInstaller.iss so the
uninstall deletes the task instead of leaving one that fails to start
every login

Updated the installer to point the Start Menu and desktop shortcuts at
DisplayHotKeysLauncher.exe

Added a launcher target to the makefile, and updated build-app-image.ps1
to copy the launcher into the app image

Updated the makefile to delete the .res.o intermediates after linking,
and updated the gitignore to drop them

Corrected the FILEVERSION of GetDisplay.rc, SetDisplay.rc, and
DisplayEventNotifier.rc to match their product versions

Changed the launch task MultipleInstancesPolicy to Parallel so a second
launch starts and reaches SingleInstanceLock, which reports that the
application is already running instead of the scheduler dropping the
launch silently

Updated LaunchTaskUtility.isTaskCurrent to compare the instance policy
so
a task registered by an earlier version is rewritten rather than kept

Moved LaunchTaskUtility.registerTask onto a background daemon thread in
DhkDriver.main so shelling out to the task command line utility no
longer
delays the view

Added DhkView.startMinimizedToTray to decide the tray handoff before the
first setVisible call so a frame bound for the tray is never shown, and
kept a rebuild off screen only when the previous frame was already away
so it returns as the user left it

Confined the settleScrollBars and correctLocation fix-ups to a frame
that
is shown, since correctLocation calls getLocationOnScreen and a packed
frame is displayable before it is showing

Called MinimizeToTray.execute from WindowController.initController when
the view held the frame back, as a frame that is never shown raises no
iconified event to hand it off

Guarded the setExtendedState call in DhkController.initController so a
frame handed to the tray keeps its state

Removed leftover settings and the scheduled task on uninstall
Added RemoveSettings and GetProfileSettingsDirs to the installer to walk
the ProfileList registry key and offer to delete the settings.ini and
lock file for every user profile that has them

Updated RemoveTask to delete the stored task definition under
{sys}\Tasks, since the schtasks command only removes the task for the
uninstalling user

Updated SingleInstanceLock.release to delete the lock file so it does
not linger in the user's documents folder after the application exits

Added PrepareToInstall and InitializeUninstall to call
ForceCloseRunningApp
before the in-use scan runs, so neither an upgrade over a running copy
nor an
uninstall prompts to close the app

Removed the ForceCloseRunningApp call from CurUninstallStepChanged since
the
kill now runs early enough to precede the scan

Added a second taskkill for DisplayHotKeysLauncher.exe, since it is a
separate
image that survives the kill targeting DisplayHotKeys.exe

Set CloseApplicationsFilter to executables and libraries to keep the
scan off
the installed data files

Created uninstall.bat to remove the scheduled task, the startup folder
fallback, and optionally the saved settings that a portable copy leaves
behind

Updated build-app-image.ps1 to copy uninstall.bat, the readme, and the
license
files into the app image so it is the complete portable package

Consolidated the [Files] entries into the single app image entry,
excluding
uninstall.bat since the installer has its own uninstaller

Set UninstallDisplayIcon so the entry in Installed apps shows the app
icon

Added RemoveStartupFiles to delete StartDisplayHotKeys.bat from each
user profile's Startup folder, and called it from
CurUninstallStepChanged, since the leftover file would fail to start the
app at every login

Extracted GetUserProfileRoots from GetProfileSettingsDirs so both the
settings and startup cleanup enumerate the real user profiles once

Wrapped the profile list iteration in try/finally so the TStringList is
freed

Added two notes to Getting Started covering that only
DisplayHotKeysLauncher.exe starts the application through the Windows
task, and that registering the task requires administrator rights

Updated the launch steps to name DisplayHotKeysLauncher rather than
DisplayHotKeys so the portable and installer instructions point at the
launcher

Reworded the elevation blurb to say display settings are set while in
video games and when an app with elevated privileges has focus, since
the UAC prompt now only appears on the first launch

Reworded the in-game use case and the apply-slot roadmap entry to say
resolution and refresh rate rather than display mode

Mirrored every wording change into distribution/README.txt

Bumped the version to 4.0.5