### PR TITLE
Run on startup refinement

### DIFF
--- a/distribution/DisplayHotKeysInstaller.iss
+++ b/distribution/DisplayHotKeysInstaller.iss
@@ -4,7 +4,7 @@
 #define MyLockFileName "DisplayHotKeys.lock"
 #define MyStartupFilePath "AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\StartDisplayHotKeys.bat"
 #define ProfileListKey "SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList"
-#define MyAppVersion "4.0.5"
+#define MyAppVersion "4.0.6"
 #define MyAppCopyright "Copyright (C) 2026 Jonathan R. Miller"
 #define MyAppPublisher "Jonathan R. Miller"
 #define MyAppURL "https://github.com/jon-mil-92/DisplayHotKeys"

--- a/distribution/build-app-image.ps1
+++ b/distribution/build-app-image.ps1
@@ -2,7 +2,7 @@
 
 $distDir = $PSScriptRoot
 $projectDir = Split-Path $distDir -Parent
-$version = '4.0.5'
+$version = '4.0.6'
 $jarName = "DisplayHotKeys-$version.jar"
 $copyright = "Copyright $([char]0x00A9) 2026 Jonathan R. Miller"
 $ErrorActionPreference = 'Stop'

--- a/distribution/build-app-image.ps1
+++ b/distribution/build-app-image.ps1
@@ -9,7 +9,7 @@ $ErrorActionPreference = 'Stop'
 $inputDir = Join-Path $distDir 'input'
 $outDir = Join-Path $distDir 'jpackage-out'
 $appImage = Join-Path $outDir 'DisplayHotKeys'
-$launcher = Join-Path $appImage 'DisplayHotKeys.exe'
+$appExe = Join-Path $appImage 'DisplayHotKeys.exe'
 $manifest = Join-Path $distDir 'DisplayHotKeys.manifest'
 $icon = Join-Path $distDir 'dhk.ico'
 $resourceDir = Join-Path $distDir 'jpackage-resources'
@@ -107,7 +107,10 @@ try {
     }
 
     # Verify the remaining packaging inputs exist before building
-    foreach ($required in @($icon, $manifest, $launcherProperties, $startLauncher, $uninstallScript) + $docFiles + ($dllNames | ForEach-Object { Join-Path $distDir $_ })) {
+    $dllFiles = $dllNames | ForEach-Object { Join-Path $distDir $_ }
+    $requiredInputs = @($icon, $manifest, $launcherProperties, $startLauncher, $uninstallScript) + $docFiles + $dllFiles
+
+    foreach ($required in $requiredInputs) {
         if (-not (Test-Path $required)) {
             throw "Required build input not found: $required"
         }
@@ -179,13 +182,13 @@ try {
         throw 'jpackage failed'
     }
 
-    # jpackage marks the launcher read-only, which blocks the resource rewrite; clear it first
-    Set-ItemProperty -Path $launcher -Name IsReadOnly -Value $false
+    # jpackage marks the app executable read-only, which blocks the resource rewrite; clear it first
+    Set-ItemProperty -Path $appExe -Name IsReadOnly -Value $false
 
-    # Replace the first resource with the Display Hot Keys manifest
+    # Replace the first resource with the manifest that raises the app to the rights it needs
     Write-Host "Injecting manifest with $mt ..."
 
-    & $mt -nologo -manifest $manifest "-outputresource:$launcher;#1"
+    & $mt -nologo -manifest $manifest "-outputresource:$appExe;#1"
 
     if ($LASTEXITCODE -ne 0) {
         throw 'mt.exe manifest injection failed'
@@ -214,11 +217,18 @@ try {
     Write-Host ''
     Write-Host "Done. App image at: $appImage"
     Write-Host 'Next: Compile DisplayHotKeysInstaller.iss (Inno Setup) to build the installer.'
+
+    $buildExitCode = 0
 } catch {
     Write-Host ''
     Write-Host "BUILD FAILED: $($_.Exception.Message)" -ForegroundColor Red
+
+    # Report the failure through the exit code so a caller chaining this script can detect it
+    $buildExitCode = 1
 } finally {
     # Keep the window open when double-clicked so the build output stays readable
     Write-Host ''
     Read-Host 'Press Enter to close this window'
+
+    exit $buildExitCode
 }

--- a/distribution/uninstall.bat
+++ b/distribution/uninstall.bat
@@ -35,7 +35,7 @@ echo.
 echo Display Hot Keys - Portable Uninstall
 echo.
 
-rem Close the running app first, since it re-registers the task on exit and holds the settings file open
+rem Close the running app first, since it holds the settings file open and would rewrite it on exit
 tasklist /fi "imagename eq %APP_EXE%" 2>nul | findstr /i /c:"%APP_EXE%" >nul
 
 if errorlevel 1 goto :queryTask

--- a/distribution/uninstall.bat
+++ b/distribution/uninstall.bat
@@ -46,15 +46,15 @@ echo Closed the running application.
 
 :queryTask
 
-rem The query reports a missing task on stderr yet still exits zero, so detect it by the absence of stdout instead
-schtasks /Query /TN "%APP_NAME%" 2>nul | findstr /b /l /i "TaskName" >nul
+rem The query reports a missing task on stderr and exits non-zero, which is enough to tell the two cases apart
+schtasks /Query /TN "%APP_NAME%" >nul 2>&1
 
 if errorlevel 1 goto :taskMissing
 
 schtasks /Delete /TN "%APP_NAME%" /F >nul 2>&1
 
-rem The delete also exits zero when it fails, so confirm removal by querying for the task again
-schtasks /Query /TN "%APP_NAME%" 2>nul | findstr /b /l /i "TaskName" >nul
+rem A delete this account lacks the rights for still leaves the task behind, so confirm it is really gone
+schtasks /Query /TN "%APP_NAME%" >nul 2>&1
 
 if not errorlevel 1 goto :taskFailed
 

--- a/jni/DisplayHotKeysLauncher.rc
+++ b/jni/DisplayHotKeysLauncher.rc
@@ -5,8 +5,8 @@
 1 ICON "../distribution/dhk.ico"
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4,0,5,0
- PRODUCTVERSION 4,0,5,0
+ FILEVERSION 4,0,6,0
+ PRODUCTVERSION 4,0,6,0
  FILEFLAGSMASK 0x3fL
  FILEFLAGS 0x0L
  FILEOS VOS_NT_WINDOWS32
@@ -18,9 +18,9 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription", "Launches Display Hot Keys"
-            VALUE "FileVersion", "4.0.5.0"
+            VALUE "FileVersion", "4.0.6.0"
             VALUE "ProductName", "Display Hot Keys"
-            VALUE "ProductVersion", "4.0.5.0"
+            VALUE "ProductVersion", "4.0.6.0"
             VALUE "LegalCopyright", "Copyright © 2026 Jonathan R. Miller"
             VALUE "OriginalFilename", "DisplayHotKeysLauncher.exe"
         END

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>DisplayHotKeys</groupId>
     <artifactId>DisplayHotKeys</artifactId>
-    <version>4.0.5</version>
+    <version>4.0.6</version>
     <name>DisplayHotKeys</name>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/dhk/controller/button/RunOnStartupButtonController.java
+++ b/src/main/java/com/dhk/controller/button/RunOnStartupButtonController.java
@@ -19,16 +19,20 @@
  */
 package com.dhk.controller.button;
 
+import javax.swing.SwingUtilities;
+
 import com.dhk.controller.IController;
 import com.dhk.io.RunOnStartupManager;
 import com.dhk.io.SettingsManager;
 import com.dhk.model.DhkModel;
+import com.dhk.model.button.ThemeableToggleButton;
 import com.dhk.view.DhkView;
-import com.dhk.view.RunOnStartupFailedDialog;
+import com.dhk.view.RunOnStartupNoticeDialog;
 
 /**
- * Controls the Run On Startup button. Listeners are added to the corresponding view component so that when the Run On
- * Startup button is pressed, the application will toggle the ability for the application to launch on user login.
+ * Controls the Run On Startup button, which toggles whether the application launches on user login. The button and the
+ * saved value both follow what is really starting the application, so a state that could not be applied is corrected
+ * rather than left showing.
  *
  * @author Jonathan R. Miller
  */
@@ -38,6 +42,8 @@ public class RunOnStartupButtonController extends AbstractButtonController imple
     private DhkView view;
     private SettingsManager settingsMgr;
     private RunOnStartupManager runOnStartupManager;
+    private boolean applyingRunOnStartup;
+    private boolean runOnStartupRequestPending;
 
     /**
      * Constructor for the {@link RunOnStartupButtonController} class.
@@ -58,6 +64,8 @@ public class RunOnStartupButtonController extends AbstractButtonController imple
     @Override
     public void initController() {
         runOnStartupManager = new RunOnStartupManager();
+
+        applySavedRunOnStartup();
     }
 
     @Override
@@ -72,22 +80,185 @@ public class RunOnStartupButtonController extends AbstractButtonController imple
     }
 
     /**
-     * Applies the toggled "run on startup" state and then saves it, so the button never shows a state the system does
-     * not have.
+     * Shows the toggled "run on startup" state and writes it, holding the write while an earlier one is still in flight
+     * so every click shows while only the state clicked last is written.
      */
     private void runOnStartupButtonAction() {
+        /*
+         * The button repaints from the state change that ends this click, which reads the on state as it is right now,
+         * so the toggle has to show here rather than after the write finishes or the icon keeps the old state
+         */
         boolean runOnStartup = !model.isRunOnStartup();
 
-        if (!applyRunOnStartup(runOnStartup)) {
-            new RunOnStartupFailedDialog().showRunOnStartupFailedDialog(runOnStartup);
+        showRunOnStartup(runOnStartup);
+
+        /*
+         * A click landing mid-write is held rather than written beside the one in flight, since the two spawn processes
+         * that would race to leave the startup state whichever finished last. Only the state shown by the click that
+         * lands last is written, so clicks collapse into one follow-up write no matter how many arrive
+         */
+        if (applyingRunOnStartup) {
+            runOnStartupRequestPending = true;
 
             return;
         }
 
-        model.setRunOnStartup(runOnStartup);
-        view.getRunOnStartupButton().setOn(runOnStartup);
+        writeRunOnStartup(runOnStartup);
+    }
+
+    /**
+     * Applies the saved "run on startup" state on launch and shows what came of it, since the button is built from the
+     * saved state while only the apply can tell whether anything is left carrying it.
+     */
+    private void applySavedRunOnStartup() {
+        boolean savedRunOnStartup = settingsMgr.getIniRunOnStartup();
+
+        applyingRunOnStartup = true;
+
+        // Registering the task costs seconds, so it stays off the startup path where nothing waits on it
+        Thread savedStateApplier = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                boolean startsOnLogon = runOnStartupManager.applySavedRunOnStartup(savedRunOnStartup);
+
+                SwingUtilities.invokeLater(new Runnable() {
+                    @Override
+                    public void run() {
+                        finishApplySavedRunOnStartup(savedRunOnStartup, startsOnLogon);
+                    }
+                });
+            }
+        });
+
+        savedStateApplier.setDaemon(true);
+        savedStateApplier.start();
+    }
+
+    /**
+     * Shows what will really start the application upon login, correcting the button when the saved state could not be
+     * put in place. A click that landed while the apply ran asked for a state of its own, which supersedes this one.
+     *
+     * @param savedRunOnStartup
+     *            - The saved state the apply was given
+     * @param startsOnLogon
+     *            - Whether the application will start upon login
+     */
+    private void finishApplySavedRunOnStartup(boolean savedRunOnStartup, boolean startsOnLogon) {
+        applyingRunOnStartup = false;
+
+        if (runOnStartupRequestPending) {
+            runOnStartupRequestPending = false;
+
+            writeRunOnStartup(model.isRunOnStartup());
+
+            return;
+        }
+
+        if (startsOnLogon == savedRunOnStartup) {
+            return;
+        }
+
+        // The saved state could not be put in place, so show and store the one the account was left with
+        showRunOnStartup(startsOnLogon);
+        repaintRunOnStartupButton();
+        settingsMgr.saveIniRunOnStartup(startsOnLogon);
+
+        new RunOnStartupNoticeDialog().showChangedNotice(startsOnLogon);
+    }
+
+    /**
+     * Writes the given "run on startup" state off the event dispatch thread, since the processes it spawns would
+     * otherwise freeze the window.
+     *
+     * @param runOnStartup
+     *            - The state to write
+     */
+    private void writeRunOnStartup(boolean runOnStartup) {
+        applyingRunOnStartup = true;
+
+        Thread runOnStartupWriter = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                boolean applied = applyRunOnStartup(runOnStartup);
+
+                SwingUtilities.invokeLater(new Runnable() {
+                    @Override
+                    public void run() {
+                        finishRunOnStartupButtonAction(runOnStartup, applied);
+                    }
+                });
+            }
+        });
+
+        // Closing the application mid-write must not be held up by the processes this spawns
+        runOnStartupWriter.setDaemon(true);
+        runOnStartupWriter.start();
+    }
+
+    /**
+     * Saves the applied "run on startup" state, or puts the button back and reports that it could not be applied.
+     *
+     * @param runOnStartup
+     *            - The state the user asked for
+     * @param applied
+     *            - Whether that state was applied
+     */
+    private void finishRunOnStartupButtonAction(boolean runOnStartup, boolean applied) {
+        applyingRunOnStartup = false;
+
+        /*
+         * Clicks that landed during the write asked for a newer state than this one, so its outcome is theirs to
+         * settle. Reporting it here would undo the state they show and report a state the user has already moved off
+         */
+        if (runOnStartupRequestPending) {
+            runOnStartupRequestPending = false;
+
+            writeRunOnStartup(model.isRunOnStartup());
+
+            return;
+        }
+
+        // Only the write can tell whether the shown state is real, so undo it here when it turned out not to be
+        if (!applied) {
+            showRunOnStartup(!runOnStartup);
+            repaintRunOnStartupButton();
+
+            // The saved value follows the button, so store the state left in place rather than the one asked for
+            settingsMgr.saveIniRunOnStartup(!runOnStartup);
+
+            new RunOnStartupNoticeDialog().showFailedNotice(runOnStartup);
+
+            return;
+        }
 
         settingsMgr.saveIniRunOnStartup(runOnStartup);
+    }
+
+    /**
+     * Shows the given "run on startup" state in the model and on the button.
+     *
+     * @param runOnStartup
+     *            - The state to show
+     */
+    private void showRunOnStartup(boolean runOnStartup) {
+        model.setRunOnStartup(runOnStartup);
+        view.getRunOnStartupButton().setOn(runOnStartup);
+    }
+
+    /**
+     * Repaints the button in the icon set its shown state now selects. No click is ending here to drive that repaint,
+     * so the icon matching where the cursor sits is chosen the same way the button itself would choose it.
+     */
+    private void repaintRunOnStartupButton() {
+        ThemeableToggleButton runOnStartupButton = view.getRunOnStartupButton();
+
+        if (runOnStartupButton.getModel().isRollover()) {
+            runOnStartupButton.updateHoverIcon();
+
+            return;
+        }
+
+        runOnStartupButton.updateIdleIcon();
     }
 
     /**

--- a/src/main/java/com/dhk/controller/button/RunOnStartupButtonController.java
+++ b/src/main/java/com/dhk/controller/button/RunOnStartupButtonController.java
@@ -24,6 +24,7 @@ import com.dhk.io.RunOnStartupManager;
 import com.dhk.io.SettingsManager;
 import com.dhk.model.DhkModel;
 import com.dhk.view.DhkView;
+import com.dhk.view.RunOnStartupFailedDialog;
 
 /**
  * Controls the Run On Startup button. Listeners are added to the corresponding view component so that when the Run On
@@ -71,20 +72,38 @@ public class RunOnStartupButtonController extends AbstractButtonController imple
     }
 
     /**
-     * Toggles the "run on startup" state, adds or removes a batch file to the startup folder, and then saves the new
-     * "run on startup" state.
+     * Applies the toggled "run on startup" state and then saves it, so the button never shows a state the system does
+     * not have.
      */
     private void runOnStartupButtonAction() {
-        model.toggleRunOnStartup();
-        view.getRunOnStartupButton().setOn(model.isRunOnStartup());
+        boolean runOnStartup = !model.isRunOnStartup();
 
-        if (model.isRunOnStartup()) {
-            runOnStartupManager.addToStartup();
-        } else {
-            runOnStartupManager.removeFromStartup();
+        if (!applyRunOnStartup(runOnStartup)) {
+            new RunOnStartupFailedDialog().showRunOnStartupFailedDialog(runOnStartup);
+
+            return;
         }
 
-        settingsMgr.saveIniRunOnStartup(model.isRunOnStartup());
+        model.setRunOnStartup(runOnStartup);
+        view.getRunOnStartupButton().setOn(runOnStartup);
+
+        settingsMgr.saveIniRunOnStartup(runOnStartup);
+    }
+
+    /**
+     * Applies the wanted "run on startup" state through the startup manager.
+     *
+     * @param runOnStartup
+     *            - Whether the application should start upon login
+     *
+     * @return True if the wanted state was applied, false if it could not be
+     */
+    private boolean applyRunOnStartup(boolean runOnStartup) {
+        if (runOnStartup) {
+            return runOnStartupManager.addToStartup();
+        }
+
+        return runOnStartupManager.removeFromStartup();
     }
 
 }

--- a/src/main/java/com/dhk/io/RunOnStartupManager.java
+++ b/src/main/java/com/dhk/io/RunOnStartupManager.java
@@ -59,22 +59,33 @@ public class RunOnStartupManager {
     }
 
     /**
-     * Applies the saved run on startup state on launch, unless only the startup folder file can carry it.
+     * Applies the saved run on startup state on launch, unless the startup folder file of this copy is already the only
+     * thing carrying it, and reports what will really start the application.
      *
      * @param runOnStartup
      *            - The saved run on startup state
+     *
+     * @return True if the application will start upon login, whether or not that is the saved state
      */
-    public void applySavedRunOnStartup(boolean runOnStartup) {
+    public boolean applySavedRunOnStartup(boolean runOnStartup) {
         /*
-         * An account that cannot register the task leaves the startup folder file carrying the state, and retrying
-         * costs two processes every launch only to fail again. The file already holds the wanted state, so reconcile
-         * only when there is a task to hand that state back to
+         * The startup folder file only survives on an account that could not write the task, where retrying costs two
+         * processes every launch to fail the same way. Skipping is only safe while that file is the sole thing starting
+         * the application, since a task that also starts it must be reconciled to stop the two stacking
          */
-        if (runOnStartupFile.exists() && !LaunchTaskUtility.isTaskRegistered()) {
-            return;
+        if (startupFileStartsThisCopy() && runOnStartup && !LaunchTaskUtility.isStartOnLogonEnabled()) {
+            return true;
         }
 
-        setRunOnStartup(runOnStartup);
+        if (setRunOnStartup(runOnStartup)) {
+            return runOnStartup;
+        }
+
+        /*
+         * The wanted state could not be written, so what starts the application is whatever the account could not
+         * change. A task left enabled still starts it, which the button has to report rather than the saved state
+         */
+        return LaunchTaskUtility.isStartOnLogonEnabled() || startupFileStartsThisCopy();
     }
 
     /**
@@ -120,10 +131,11 @@ public class RunOnStartupManager {
         }
 
         /*
-         * Nothing here could write the wanted state. Turning it off still succeeds when no task starts the application
-         * anyway, but a task an administrator registered earlier keeps doing so until it can be rewritten
+         * Nothing here could write the wanted state, so report what the system will actually do rather than what was
+         * asked for. A task registered against stricter rights than this account holds keeps its own trigger state,
+         * which already matches whenever the wanted state is off and no task starts the application
          */
-        return !runOnStartup && !LaunchTaskUtility.isTaskRegistered();
+        return LaunchTaskUtility.isStartOnLogonEnabled() == runOnStartup;
     }
 
     /**
@@ -152,6 +164,28 @@ public class RunOnStartupManager {
         }
 
         return true;
+    }
+
+    /**
+     * Determines whether the startup folder file starts this copy of the application. A portable copy that moved leaves
+     * one naming a path that no longer holds the application, which must be rewritten rather than trusted.
+     *
+     * @return True if the file exists and names this copy's executable, false otherwise
+     */
+    private boolean startupFileStartsThisCopy() {
+        String appExePath = LaunchTaskUtility.getAppExePath();
+
+        if (appExePath == null || !runOnStartupFile.exists()) {
+            return false;
+        }
+
+        try {
+            return Files.readString(runOnStartupFile.toPath()).contains(appExePath);
+        } catch (IOException e) {
+            e.printStackTrace();
+
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/com/dhk/io/RunOnStartupManager.java
+++ b/src/main/java/com/dhk/io/RunOnStartupManager.java
@@ -35,73 +35,107 @@ import com.dhk.utility.LaunchTaskUtility;
  */
 public class RunOnStartupManager {
 
-    private String startupPath;
-    private String runOnStartupFileName;
-    private String runOnStartupFilePath;
+    /**
+     * The startup folder batch file that starts the application upon login.
+     */
     private File runOnStartupFile;
+
+    /**
+     * Path of the startup folder, relative to the user's home folder, that Windows runs the contents of upon login.
+     */
+    private static final String STARTUP_PATH = "\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs"
+            + "\\Startup\\";
+
+    /**
+     * Name of the batch file that starts the application upon login while the task cannot be registered.
+     */
+    private static final String RUN_ON_STARTUP_FILE_NAME = "StartDisplayHotKeys.bat";
 
     /**
      * Constructor for the {@link RunOnStartupManager} class.
      */
     public RunOnStartupManager() {
-        startupPath = System.getProperty("user.home")
-                + "\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\";
+        runOnStartupFile = new File(System.getProperty("user.home") + STARTUP_PATH + RUN_ON_STARTUP_FILE_NAME);
+    }
 
-        runOnStartupFileName = "StartDisplayHotKeys.bat";
-        runOnStartupFilePath = startupPath + runOnStartupFileName;
-        runOnStartupFile = new File(runOnStartupFilePath);
+    /**
+     * Applies the saved run on startup state on launch, unless only the startup folder file can carry it.
+     *
+     * @param runOnStartup
+     *            - The saved run on startup state
+     */
+    public void applySavedRunOnStartup(boolean runOnStartup) {
+        /*
+         * An account that cannot register the task leaves the startup folder file carrying the state, and retrying
+         * costs two processes every launch only to fail again. The file already holds the wanted state, so reconcile
+         * only when there is a task to hand that state back to
+         */
+        if (runOnStartupFile.exists() && !LaunchTaskUtility.isTaskRegistered()) {
+            return;
+        }
+
+        setRunOnStartup(runOnStartup);
     }
 
     /**
      * Enables the logon trigger of the task so the application starts upon login.
+     *
+     * @return True if the application will start upon login, false if neither mechanism could be enabled
      */
-    public void addToStartup() {
-        setRunOnStartup(true);
+    public boolean addToStartup() {
+        return setRunOnStartup(true);
     }
 
     /**
      * Disables the logon trigger of the task so it no longer starts the application on login. The task itself stays
      * registered so the launcher can start the application elevated without a consent prompt after the first launch.
+     *
+     * @return True if the application will no longer start upon login, false if the task could not be rewritten
      */
-    public void removeFromStartup() {
-        setRunOnStartup(false);
+    public boolean removeFromStartup() {
+        return setRunOnStartup(false);
     }
 
     /**
-     * Applies the wanted run on startup state through the task's logon trigger, falling back to the startup folder when
-     * the task cannot be registered.
+     * Applies the wanted run on startup state through the task's logon trigger, falling back to the startup folder only
+     * while the task cannot be registered. Exactly one of the two ever survives a call, since both would start the
+     * application twice upon login.
      *
      * @param runOnStartup
      *            - Whether the application should start upon login
+     *
+     * @return True if the wanted state was applied, false if it could not be
      */
-    private void setRunOnStartup(boolean runOnStartup) {
-        if (LaunchTaskUtility.registerTask(runOnStartup)) {
-            removeStartupFile();
+    private boolean setRunOnStartup(boolean runOnStartup) {
+        // The task carries the state whenever it can, so the fallback it replaces must not survive beside it
+        boolean taskCarriesState = LaunchTaskUtility.registerTask(runOnStartup);
+        boolean fallbackCarriesState = !taskCarriesState && runOnStartup && addStartupFile();
 
-            return;
+        if (!fallbackCarriesState) {
+            removeStartupFile();
+        }
+
+        if (taskCarriesState || fallbackCarriesState) {
+            return true;
         }
 
         /*
-         * Registering the task needs administrator rights, which a standard account never has. Fall back to the startup
-         * folder batch file so the setting still works there, at the cost of the login console flash
+         * Nothing here could write the wanted state. Turning it off still succeeds when no task starts the application
+         * anyway, but a task an administrator registered earlier keeps doing so until it can be rewritten
          */
-        if (runOnStartup) {
-            addStartupFile();
-
-            return;
-        }
-
-        removeStartupFile();
+        return !runOnStartup && !LaunchTaskUtility.isTaskRegistered();
     }
 
     /**
      * Adds a batch file to the user's startup folder that will execute this application upon login.
+     *
+     * @return True if the batch file was written, false otherwise
      */
-    private void addStartupFile() {
+    private boolean addStartupFile() {
         String appExePath = LaunchTaskUtility.getAppExePath();
 
         if (appExePath == null) {
-            return;
+            return false;
         }
 
         try {
@@ -113,7 +147,11 @@ public class RunOnStartupManager {
             startupFileWriter.close();
         } catch (FileNotFoundException e) {
             e.printStackTrace();
+
+            return false;
         }
+
+        return true;
     }
 
     /**

--- a/src/main/java/com/dhk/io/SettingsValidator.java
+++ b/src/main/java/com/dhk/io/SettingsValidator.java
@@ -49,7 +49,6 @@ public class SettingsValidator {
     private Map<String, DisplayMode[]> landscapeDisplayModesMap;
     private Map<String, DisplayMode[]> portraitDisplayModesMap;
     private List<Integer> validkeyCodes;
-    private RunOnStartupManager runOnStartupManager;
 
     private static final int UNSET_KEY_CODE = 0;
     private static final String[] VALID_SCALING_MODES = {"0", "1", "2"};
@@ -69,7 +68,6 @@ public class SettingsValidator {
         landscapeDisplayModesMap = settingsMgr.getLandscapeDisplayModesMap();
         portraitDisplayModesMap = settingsMgr.getPortraitDisplayModesMap();
         validkeyCodes = buildValidKeyCodes();
-        runOnStartupManager = new RunOnStartupManager();
     }
 
     /**
@@ -190,9 +188,9 @@ public class SettingsValidator {
     private void validateRunOnStartup() {
         String runOnStartup = ini.get("Application", "runOnStartup");
 
+        // Only repair the stored value here; the repaired state reaches the system through applySavedRunOnStartup
         if (runOnStartup == null || !(runOnStartup.equals("false") || runOnStartup.equals("true"))) {
             settingsMgr.saveIniRunOnStartup(false);
-            runOnStartupManager.removeFromStartup();
         }
     }
 

--- a/src/main/java/com/dhk/main/DhkDriver.java
+++ b/src/main/java/com/dhk/main/DhkDriver.java
@@ -23,11 +23,11 @@ import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
 
 import com.dhk.controller.DhkController;
+import com.dhk.io.RunOnStartupManager;
 import com.dhk.io.SettingsManager;
 import com.dhk.io.SingleInstanceLock;
 import com.dhk.model.DhkModel;
 import com.dhk.theme.ThemeUpdater;
-import com.dhk.utility.LaunchTaskUtility;
 import com.dhk.view.AlreadyRunningDialog;
 import com.dhk.view.DhkView;
 
@@ -74,14 +74,13 @@ public class DhkDriver {
         settingsMgr.initSettingsManager();
 
         /*
-         * Register the task that runs this application elevated, whether or not it should start on login, so the
-         * launcher can start it without a consent prompt after the first launch. Registration shells out to the task
-         * command line utility, which costs seconds, so it runs off the startup path where nothing waits on it
+         * Register the task that starts this application elevated, whether or not it should start on login. This costs
+         * seconds, so it runs off the startup path where nothing waits on it
          */
         Thread taskRegistration = new Thread(new Runnable() {
             @Override
             public void run() {
-                LaunchTaskUtility.registerTask(settingsMgr.getIniRunOnStartup());
+                new RunOnStartupManager().applySavedRunOnStartup(settingsMgr.getIniRunOnStartup());
             }
         });
 

--- a/src/main/java/com/dhk/main/DhkDriver.java
+++ b/src/main/java/com/dhk/main/DhkDriver.java
@@ -23,7 +23,6 @@ import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
 
 import com.dhk.controller.DhkController;
-import com.dhk.io.RunOnStartupManager;
 import com.dhk.io.SettingsManager;
 import com.dhk.io.SingleInstanceLock;
 import com.dhk.model.DhkModel;
@@ -72,20 +71,6 @@ public class DhkDriver {
 
         SettingsManager settingsMgr = new SettingsManager();
         settingsMgr.initSettingsManager();
-
-        /*
-         * Register the task that starts this application elevated, whether or not it should start on login. This costs
-         * seconds, so it runs off the startup path where nothing waits on it
-         */
-        Thread taskRegistration = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                new RunOnStartupManager().applySavedRunOnStartup(settingsMgr.getIniRunOnStartup());
-            }
-        });
-
-        taskRegistration.setDaemon(true);
-        taskRegistration.start();
 
         SwingUtilities.invokeLater(new Runnable() {
             @Override

--- a/src/main/java/com/dhk/model/DhkModel.java
+++ b/src/main/java/com/dhk/model/DhkModel.java
@@ -202,10 +202,13 @@ public class DhkModel {
     }
 
     /**
-     * Toggles the "run on startup" state.
+     * Sets the "run on startup" state.
+     *
+     * @param runOnStartup
+     *            - The "run on startup" state to set
      */
-    public void toggleRunOnStartup() {
-        runOnStartup = !runOnStartup;
+    public void setRunOnStartup(boolean runOnStartup) {
+        this.runOnStartup = runOnStartup;
     }
 
     /**

--- a/src/main/java/com/dhk/utility/LaunchTaskUtility.java
+++ b/src/main/java/com/dhk/utility/LaunchTaskUtility.java
@@ -23,6 +23,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Registers the task that runs this application with the highest available privileges, so the launcher can start the
@@ -39,6 +42,11 @@ public class LaunchTaskUtility {
     private static final String TASK_NAME = "Display Hot Keys";
 
     /**
+     * Command line utility that reads and writes tasks.
+     */
+    private static final String TASK_COMMAND = "schtasks";
+
+    /**
      * Exit code returned by the task command line utility when a command succeeds.
      */
     private static final int TASK_COMMAND_SUCCESS = 0;
@@ -48,6 +56,26 @@ public class LaunchTaskUtility {
      * reports that the application is already running. Suppressing it here would drop the launch silently instead.
      */
     private static final String MULTIPLE_INSTANCES_POLICY = "Parallel";
+
+    /**
+     * Opening element of the block holding the task's triggers.
+     */
+    private static final String TRIGGERS_OPEN_ELEMENT = "<Triggers>";
+
+    /**
+     * Closing element of the block holding the task's triggers.
+     */
+    private static final String TRIGGERS_CLOSE_ELEMENT = "</Triggers>";
+
+    /**
+     * Opening tag of the logon trigger, matched without its closing bracket so it also finds the self-closing form.
+     */
+    private static final String LOGON_TRIGGER_ELEMENT = "<LogonTrigger";
+
+    /**
+     * Element marking the enclosing trigger as disabled.
+     */
+    private static final String DISABLED_ELEMENT = "<Enabled>false</Enabled>";
 
     /**
      * Little endian UTF-16 byte order mark that must precede a task definition.
@@ -75,6 +103,7 @@ public class LaunchTaskUtility {
      * @return True if the task is registered and current, false otherwise
      */
     public static boolean registerTask(boolean runOnStartup) {
+        // Everything below builds the definition around this path, so nothing past here has to null check it again
         if (APP_EXE_PATH == null) {
             return false;
         }
@@ -97,13 +126,25 @@ public class LaunchTaskUtility {
     }
 
     /**
-     * Determines whether the task is registered, which decides both whether registering it again is worth the process
-     * it costs and whether a task that could not be rewritten still starts the application upon login.
+     * Determines whether the task is registered, which decides whether an account that cannot write the task still has
+     * one that starts the application upon login.
      *
      * @return True if the task is registered, false otherwise
      */
     public static boolean isTaskRegistered() {
         return queryTaskXml() != null;
+    }
+
+    /**
+     * Reads the logon trigger state the registered task currently carries, which is the state the system will actually
+     * act on rather than the one that was last requested.
+     *
+     * @return True if a task is registered and its logon trigger is enabled, false otherwise
+     */
+    public static boolean isStartOnLogonEnabled() {
+        String taskXml = queryTaskXml();
+
+        return taskXml != null && isTriggerEnabled(taskXml);
     }
 
     /**
@@ -144,12 +185,28 @@ public class LaunchTaskUtility {
      * @return True if the logon trigger is enabled, false otherwise
      */
     private static boolean isTriggerEnabled(String taskXml) {
+        int triggersStart = taskXml.indexOf(TRIGGERS_OPEN_ELEMENT);
+        int triggersEnd = taskXml.indexOf(TRIGGERS_CLOSE_ELEMENT, triggersStart);
+
+        // A definition carrying no trigger block cannot start the application upon login
+        if (triggersStart == -1 || triggersEnd == -1) {
+            return false;
+        }
+
+        String triggers = taskXml.substring(triggersStart + TRIGGERS_OPEN_ELEMENT.length(), triggersEnd);
+
+        // Neither can one whose trigger block is empty, which is what a definition stripped of its trigger leaves
+        if (triggers.indexOf(LOGON_TRIGGER_ELEMENT) == -1) {
+            return false;
+        }
+
         /*
          * The scheduler rewrites the definition it stores, collapsing an enabled trigger to a self-closing element that
          * omits the default, so detect the disabled state and infer the enabled one rather than matching what was
-         * written
+         * written. The search stays inside the trigger block because the settings block carries its own enabled element
+         * that reflects the whole task rather than the trigger
          */
-        return !taskXml.contains("<Enabled>false</Enabled>");
+        return !triggers.contains(DISABLED_ELEMENT);
     }
 
     /**
@@ -158,7 +215,7 @@ public class LaunchTaskUtility {
      * @return The task definition XML, or null when the task is not registered
      */
     private static String queryTaskXml() {
-        ProcessBuilder taskQueryBuilder = new ProcessBuilder("schtasks", "/Query", "/TN", TASK_NAME, "/XML");
+        ProcessBuilder taskQueryBuilder = new ProcessBuilder(TASK_COMMAND, "/Query", "/TN", TASK_NAME, "/XML");
         taskQueryBuilder.redirectErrorStream(true);
 
         try {
@@ -228,12 +285,9 @@ public class LaunchTaskUtility {
      * @return True if the command succeeded, false otherwise
      */
     private static boolean runTaskCommand(String... taskArguments) {
-        String[] taskCommand = new String[taskArguments.length + 1];
-        taskCommand[0] = "schtasks";
-
-        for (int argumentIndex = 0; argumentIndex < taskArguments.length; argumentIndex++) {
-            taskCommand[argumentIndex + 1] = taskArguments[argumentIndex];
-        }
+        List<String> taskCommand = new ArrayList<String>();
+        taskCommand.add(TASK_COMMAND);
+        taskCommand.addAll(Arrays.asList(taskArguments));
 
         ProcessBuilder taskCommandBuilder = new ProcessBuilder(taskCommand);
         taskCommandBuilder.redirectErrorStream(true);

--- a/src/main/java/com/dhk/utility/LaunchTaskUtility.java
+++ b/src/main/java/com/dhk/utility/LaunchTaskUtility.java
@@ -19,9 +19,7 @@
  */
 package com.dhk.utility;
 
-import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -55,11 +53,6 @@ public class LaunchTaskUtility {
      * Little endian UTF-16 byte order mark that must precede a task definition.
      */
     private static final byte[] BYTE_ORDER_MARK = {(byte) 0xFF, (byte) 0xFE};
-
-    /**
-     * File extension that a derived path must carry to be a runnable task command.
-     */
-    private static final String EXE_EXTENSION = ".exe";
 
     /**
      * Path of the executable the task runs, resolved once because it cannot change while the application runs.
@@ -104,6 +97,16 @@ public class LaunchTaskUtility {
     }
 
     /**
+     * Determines whether the task is registered, which decides both whether registering it again is worth the process
+     * it costs and whether a task that could not be rewritten still starts the application upon login.
+     *
+     * @return True if the task is registered, false otherwise
+     */
+    public static boolean isTaskRegistered() {
+        return queryTaskXml() != null;
+    }
+
+    /**
      * Determines whether the task is registered and already matches the running executable, the wanted logon trigger
      * state, and the wanted instance policy. A portable copy can move between launches, which leaves a stale task that
      * would silently fail to start.
@@ -129,14 +132,24 @@ public class LaunchTaskUtility {
             return false;
         }
 
+        return isTriggerEnabled(taskXml) == runOnStartup;
+    }
+
+    /**
+     * Reads the logon trigger state out of a task definition.
+     *
+     * @param taskXml
+     *            - The task definition XML to read
+     *
+     * @return True if the logon trigger is enabled, false otherwise
+     */
+    private static boolean isTriggerEnabled(String taskXml) {
         /*
          * The scheduler rewrites the definition it stores, collapsing an enabled trigger to a self-closing element that
          * omits the default, so detect the disabled state and infer the enabled one rather than matching what was
          * written
          */
-        boolean triggerDisabled = taskXml.contains("<Enabled>false</Enabled>");
-
-        return triggerDisabled != runOnStartup;
+        return !taskXml.contains("<Enabled>false</Enabled>");
     }
 
     /**
@@ -334,50 +347,15 @@ public class LaunchTaskUtility {
     /**
      * Resolves the path of the executable that the task runs.
      *
-     * @return The application executable path, or null if it does not resolve to an executable
+     * @return The application executable path, or null when the application is not running from its own executable
      */
     private static String resolveAppExePath() {
-        // The jpackage launcher exposes its own executable path here; fall back to the code source when unpackaged
-        String appExePath = System.getProperty("jpackage.app-path");
-
-        if (appExePath != null) {
-            return appExePath;
-        }
-
-        return deriveExePathFromCodeSource();
-    }
-
-    /**
-     * Derives the executable path from the running code source for unpackaged runs.
-     *
-     * @return The derived executable path, or null if the code source does not resolve to an executable
-     */
-    private static String deriveExePathFromCodeSource() {
-        File jarFile = null;
-
-        try {
-            jarFile = new File(
-                    LaunchTaskUtility.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath());
-        } catch (URISyntaxException e) {
-            e.printStackTrace();
-        }
-
-        if (jarFile == null) {
-            return null;
-        }
-
-        String derivedPath = jarFile.getPath().replaceAll(".jar", ".exe");
-
         /*
-         * Running from a development environment resolves the code source to a class output directory, which leaves
-         * nothing to replace. The task command line utility accepts a directory without complaint, so registering that
-         * path would yield a task that can never start the application
+         * Only the packaged launcher sets this, and it is the executable both the installed and portable packages run.
+         * A development run has no executable of its own, and registering a task that starts a class output directory
+         * would only yield one that can never start the application
          */
-        if (!derivedPath.toLowerCase().endsWith(EXE_EXTENSION)) {
-            return null;
-        }
-
-        return derivedPath;
+        return System.getProperty("jpackage.app-path");
     }
 
 }

--- a/src/main/java/com/dhk/utility/LaunchTaskUtility.java
+++ b/src/main/java/com/dhk/utility/LaunchTaskUtility.java
@@ -126,16 +126,6 @@ public class LaunchTaskUtility {
     }
 
     /**
-     * Determines whether the task is registered, which decides whether an account that cannot write the task still has
-     * one that starts the application upon login.
-     *
-     * @return True if the task is registered, false otherwise
-     */
-    public static boolean isTaskRegistered() {
-        return queryTaskXml() != null;
-    }
-
-    /**
      * Reads the logon trigger state the registered task currently carries, which is the state the system will actually
      * act on rather than the one that was last requested.
      *

--- a/src/main/java/com/dhk/view/AboutDialog.java
+++ b/src/main/java/com/dhk/view/AboutDialog.java
@@ -86,8 +86,8 @@ public class AboutDialog implements IView {
     private Component darkeningGlassPane;
 
     private static final String GITHUB_DOMAIN = "https://github.com";
-    private static final String REALEASES_PATH = "/jon-mil-92/DisplayHotKeys/releases";
-    private static final String RELEASES_LINK = GITHUB_DOMAIN + REALEASES_PATH;
+    private static final String RELEASES_PATH = "/jon-mil-92/DisplayHotKeys/releases";
+    private static final String RELEASES_LINK = GITHUB_DOMAIN + RELEASES_PATH;
     private static final float HEADER_FONT_SCALE = 1.6f;
 
     /**

--- a/src/main/java/com/dhk/view/RunOnStartupFailedDialog.java
+++ b/src/main/java/com/dhk/view/RunOnStartupFailedDialog.java
@@ -32,33 +32,60 @@ import javax.swing.JLabel;
 import javax.swing.SwingConstants;
 
 /**
- * Shows a modal, icon-free dialog reporting that another instance is already running.
+ * Shows a modal, icon-free dialog reporting why the run on startup setting could not be changed.
  *
  * @author Jonathan R. Miller
  */
-public class AlreadyRunningDialog {
+public class RunOnStartupFailedDialog {
 
     /**
-     * Message reporting that another instance already holds the single instance lock.
+     * Message shown above the reason lines.
      */
-    private static final String MESSAGE_TEXT = "Display Hot Keys is already running!";
+    private static final String MESSAGE_TEXT = "Run On Startup could not be changed!";
 
     /**
-     * Default constructor for the {@link AlreadyRunningDialog} class.
+     * First reason line shown when the setting could not be turned off.
      */
-    public AlreadyRunningDialog() {
+    private static final String DISABLE_REASON_LINE_1 = "A scheduled task still starts the app upon login,";
+
+    /**
+     * Second reason line shown when the setting could not be turned off.
+     */
+    private static final String DISABLE_REASON_LINE_2 = "and removing it requires administrator rights.";
+
+    /**
+     * First reason line shown when the setting could not be turned on.
+     */
+    private static final String ENABLE_REASON_LINE_1 = "The scheduled task could not be registered,";
+
+    /**
+     * Second reason line shown when the setting could not be turned on.
+     */
+    private static final String ENABLE_REASON_LINE_2 = "and the startup folder could not be written to.";
+
+    /**
+     * Default constructor for the {@link RunOnStartupFailedDialog} class.
+     */
+    public RunOnStartupFailedDialog() {
     }
 
     /**
-     * Shows the modal "already running" dialog with a centered message above a centered Close button.
+     * Shows the modal "run on startup failed" dialog with centered message lines above a centered Close button.
+     *
+     * @param runOnStartup
+     *            - The state the user asked for, which decides the reason shown
      */
-    public void showAlreadyRunningDialog() {
+    public void showRunOnStartupFailedDialog(boolean runOnStartup) {
         final JDialog dialog = new JDialog((JFrame) null, "Display Hot Keys", true);
         dialog.setResizable(false);
         dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
         dialog.setLayout(new GridBagLayout());
 
         JLabel message = new JLabel(MESSAGE_TEXT, SwingConstants.CENTER);
+        JLabel reasonLine1 = new JLabel(runOnStartup ? ENABLE_REASON_LINE_1 : DISABLE_REASON_LINE_1,
+                SwingConstants.CENTER);
+        JLabel reasonLine2 = new JLabel(runOnStartup ? ENABLE_REASON_LINE_2 : DISABLE_REASON_LINE_2,
+                SwingConstants.CENTER);
         JButton closeButton = new JButton("Close");
 
         // Suppress the focus ring
@@ -73,12 +100,22 @@ public class AlreadyRunningDialog {
         GridBagConstraints constraints = new GridBagConstraints();
         constraints.gridx = 0;
         constraints.gridy = 0;
-        constraints.insets = new Insets(28, 28, 28, 28);
+        constraints.insets = new Insets(28, 36, 16, 36);
 
         dialog.add(message, constraints);
 
         constraints.gridy = 1;
-        constraints.insets = new Insets(0, 0, 18, 0);
+        constraints.insets = new Insets(0, 36, 2, 36);
+
+        dialog.add(reasonLine1, constraints);
+
+        constraints.gridy = 2;
+        constraints.insets = new Insets(0, 36, 24, 36);
+
+        dialog.add(reasonLine2, constraints);
+
+        constraints.gridy = 3;
+        constraints.insets = new Insets(0, 0, 22, 0);
 
         dialog.add(closeButton, constraints);
 

--- a/src/main/java/com/dhk/view/RunOnStartupNoticeDialog.java
+++ b/src/main/java/com/dhk/view/RunOnStartupNoticeDialog.java
@@ -70,26 +70,17 @@ public class RunOnStartupNoticeDialog {
     private static final String ENABLE_REASON_LINE_2 = "and the startup folder could not be written to.";
 
     /**
-     * First reason line shown when the setting was turned on because the task that starts the app could not be turned
-     * off.
+     * First reason line shown when the setting was corrected on launch, which both corrections open with.
      */
-    private static final String CHANGED_ON_REASON_LINE_1 = "The task that starts the app upon login could not be";
+    private static final String CHANGED_REASON_LINE_1 = "The task that starts the app upon login could not be";
 
     /**
-     * Second reason line shown when the setting was turned on because the task that starts the app could not be turned
-     * off.
+     * Second reason line shown when the setting was turned on because that task could not be turned off.
      */
     private static final String CHANGED_ON_REASON_LINE_2 = "turned off without administrator rights.";
 
     /**
-     * First reason line shown when the setting was turned off because the task that starts the app could not be
-     * created.
-     */
-    private static final String CHANGED_OFF_REASON_LINE_1 = "The task that starts the app upon login could not be";
-
-    /**
-     * Second reason line shown when the setting was turned off because the task that starts the app could not be
-     * created.
+     * Second reason line shown when the setting was turned off because that task could not be created.
      */
     private static final String CHANGED_OFF_REASON_LINE_2 = "created without administrator rights.";
 
@@ -118,7 +109,7 @@ public class RunOnStartupNoticeDialog {
      *            - The state the setting was corrected to, which decides the reason shown
      */
     public void showChangedNotice(boolean startsOnLogon) {
-        showDialog(CHANGED_MESSAGE_TEXT, startsOnLogon ? CHANGED_ON_REASON_LINE_1 : CHANGED_OFF_REASON_LINE_1,
+        showDialog(CHANGED_MESSAGE_TEXT, CHANGED_REASON_LINE_1,
                 startsOnLogon ? CHANGED_ON_REASON_LINE_2 : CHANGED_OFF_REASON_LINE_2);
     }
 

--- a/src/main/java/com/dhk/view/RunOnStartupNoticeDialog.java
+++ b/src/main/java/com/dhk/view/RunOnStartupNoticeDialog.java
@@ -32,16 +32,22 @@ import javax.swing.JLabel;
 import javax.swing.SwingConstants;
 
 /**
- * Shows a modal, icon-free dialog reporting why the run on startup setting could not be changed.
+ * Shows a modal, icon-free dialog reporting why the run on startup setting could not be changed, or why it was
+ * corrected on launch to match what really starts the application.
  *
  * @author Jonathan R. Miller
  */
-public class RunOnStartupFailedDialog {
+public class RunOnStartupNoticeDialog {
 
     /**
-     * Message shown above the reason lines.
+     * Message shown above the reason lines when a requested change could not be made.
      */
-    private static final String MESSAGE_TEXT = "Run On Startup could not be changed!";
+    private static final String FAILED_MESSAGE_TEXT = "Run On Startup could not be changed!";
+
+    /**
+     * Message shown above the reason lines when the saved setting was corrected on launch rather than by a click.
+     */
+    private static final String CHANGED_MESSAGE_TEXT = "Run On Startup was changed to match the scheduled task!";
 
     /**
      * First reason line shown when the setting could not be turned off.
@@ -64,28 +70,77 @@ public class RunOnStartupFailedDialog {
     private static final String ENABLE_REASON_LINE_2 = "and the startup folder could not be written to.";
 
     /**
-     * Default constructor for the {@link RunOnStartupFailedDialog} class.
+     * First reason line shown when the setting was turned on because the task that starts the app could not be turned
+     * off.
      */
-    public RunOnStartupFailedDialog() {
+    private static final String CHANGED_ON_REASON_LINE_1 = "The task that starts the app upon login could not be";
+
+    /**
+     * Second reason line shown when the setting was turned on because the task that starts the app could not be turned
+     * off.
+     */
+    private static final String CHANGED_ON_REASON_LINE_2 = "turned off without administrator rights.";
+
+    /**
+     * First reason line shown when the setting was turned off because the task that starts the app could not be
+     * created.
+     */
+    private static final String CHANGED_OFF_REASON_LINE_1 = "The task that starts the app upon login could not be";
+
+    /**
+     * Second reason line shown when the setting was turned off because the task that starts the app could not be
+     * created.
+     */
+    private static final String CHANGED_OFF_REASON_LINE_2 = "created without administrator rights.";
+
+    /**
+     * Default constructor for the {@link RunOnStartupNoticeDialog} class.
+     */
+    public RunOnStartupNoticeDialog() {
     }
 
     /**
-     * Shows the modal "run on startup failed" dialog with centered message lines above a centered Close button.
+     * Shows the modal notice reporting that a requested change to the setting could not be made.
      *
      * @param runOnStartup
      *            - The state the user asked for, which decides the reason shown
      */
-    public void showRunOnStartupFailedDialog(boolean runOnStartup) {
+    public void showFailedNotice(boolean runOnStartup) {
+        showDialog(FAILED_MESSAGE_TEXT, runOnStartup ? ENABLE_REASON_LINE_1 : DISABLE_REASON_LINE_1,
+                runOnStartup ? ENABLE_REASON_LINE_2 : DISABLE_REASON_LINE_2);
+    }
+
+    /**
+     * Shows the modal notice reporting that the saved setting was corrected on launch to match what really starts the
+     * application, since the account could not change it.
+     *
+     * @param startsOnLogon
+     *            - The state the setting was corrected to, which decides the reason shown
+     */
+    public void showChangedNotice(boolean startsOnLogon) {
+        showDialog(CHANGED_MESSAGE_TEXT, startsOnLogon ? CHANGED_ON_REASON_LINE_1 : CHANGED_OFF_REASON_LINE_1,
+                startsOnLogon ? CHANGED_ON_REASON_LINE_2 : CHANGED_OFF_REASON_LINE_2);
+    }
+
+    /**
+     * Shows the modal dialog with centered message lines above a centered Close button.
+     *
+     * @param messageText
+     *            - The message shown above the reason lines
+     * @param reasonText1
+     *            - The first reason line
+     * @param reasonText2
+     *            - The second reason line
+     */
+    private void showDialog(String messageText, String reasonText1, String reasonText2) {
         final JDialog dialog = new JDialog((JFrame) null, "Display Hot Keys", true);
         dialog.setResizable(false);
         dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
         dialog.setLayout(new GridBagLayout());
 
-        JLabel message = new JLabel(MESSAGE_TEXT, SwingConstants.CENTER);
-        JLabel reasonLine1 = new JLabel(runOnStartup ? ENABLE_REASON_LINE_1 : DISABLE_REASON_LINE_1,
-                SwingConstants.CENTER);
-        JLabel reasonLine2 = new JLabel(runOnStartup ? ENABLE_REASON_LINE_2 : DISABLE_REASON_LINE_2,
-                SwingConstants.CENTER);
+        JLabel message = new JLabel(messageText, SwingConstants.CENTER);
+        JLabel reasonLine1 = new JLabel(reasonText1, SwingConstants.CENTER);
+        JLabel reasonLine2 = new JLabel(reasonText2, SwingConstants.CENTER);
         JButton closeButton = new JButton("Close");
 
         // Suppress the focus ring


### PR DESCRIPTION
Display Hot Keys 4.0.6 - Internal Developer Notes (v4.0.5 to v4.0.6)

Refined the run on startup behavior so the button, the saved value, and what the system will really do upon login all follow what is actually registered rather than the state that was last requested

Added LaunchTaskUtility.isStartOnLogonEnabled to read the logon trigger state the registered task carries, so the state acted on is read rather than the one last requested

Narrowed LaunchTaskUtility.isTriggerEnabled to search inside the trigger block, since the settings block carries its own enabled element that reflects the whole task and the old whole-document search matched it, and treated a missing or empty trigger block as disabled

Removed LaunchTaskUtility.isTaskRegistered, as LaunchTaskUtility.isStartOnLogonEnabled covers what the startup state is now read from

Extracted the schtasks literal to TASK_COMMAND, and replaced the manual array copy in LaunchTaskUtility.runTaskCommand with List and Arrays.asList

Changed RunOnStartupManager.applySavedRunOnStartup to return what will really start the application rather than whether the saved state was written, returning LaunchTaskUtility.isStartOnLogonEnabled or RunOnStartupManager.startupFileStartsThisCopy when the write fails, so a task left enabled that the account cannot disable is reported instead of the saved state

Reworked RunOnStartupManager.setRunOnStartup so exactly one of the task logon trigger and the startup folder file ever survives a call, since both would start the application twice upon login, and returned whether reality matches what was asked

Moved the launch apply out of DhkDriver into RunOnStartupButtonController.initController, which owns the model and the button and runs after the view exists, since DhkDriver discarded the result while the button was built from the ini-seeded model, and the old thread could finish before there was a button to correct

Held a click that lands while a write is in flight in RunOnStartupButtonController.runOnStartupButtonAction instead of dropping it, showing the state before the guard so every click changes the icon, and extracted the writer thread into RunOnStartupButtonController.writeRunOnStartup so the follow-up write reuses it

Coalesced held clicks through the runOnStartupRequestPending boolean, so any number of clicks during one write collapse into a single follow-up write of the state clicked last

Suppressed the failure report in RunOnStartupButtonController.finishRunOnStartupButtonAction while a request is pending, since reverting would clobber the newer state the click shows and report one the user already moved off, leaving the follow-up write to settle the icon and any dialog

Saved the state left in place when a click could not be applied, since the stored value follows the button and that path previously reverted without saving at all

Renamed RunOnStartupFailedDialog to RunOnStartupNoticeDialog, as it now reports a correction made on launch as well as a refused change, and added RunOnStartupNoticeDialog.showChangedNotice naming the task that could not be created or turned off without administrator rights

Extracted the dialog layout into a private RunOnStartupNoticeDialog.showDialog so both notices build the same window, and merged the reason line both corrections open with into CHANGED_REASON_LINE_1

Replaced DhkModel.toggleRunOnStartup with DhkModel.setRunOnStartup so the controller can drive the state it already resolved

Stopped SettingsValidator.validateRunOnStartup from writing the startup state itself, which is now required since it would otherwise fight the controller's apply, as the repaired value reaches the system through RunOnStartupManager.applySavedRunOnStartup

Replaced the stdout parsing in uninstall.bat with the exit code of the task query, since a missing task exits non-zero, and kept the post-delete re-query because an unprivileged delete reports success and leaves the task behind

Updated build-app-image.ps1 to exit with the build result so a caller chaining it can detect a failure, and renamed its launcher path variable to appExe to separate it from the launcher copied in beside it

Bumped the version to 4.0.6 in pom.xml, DisplayHotKeysInstaller.iss, and DisplayHotKeysLauncher.rc, leaving the three JNI DLL versions alone since no native source changed